### PR TITLE
adapted the crossbutton icon size

### DIFF
--- a/packages/components/src/button/src/CrossButton.css
+++ b/packages/components/src/button/src/CrossButton.css
@@ -1,0 +1,9 @@
+.o-ui-button-sm.o-ui-icon-button.o-ui-cross-button .o-ui-button-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+}
+
+.o-ui-button-md.o-ui-icon-button.o-ui-cross-button .o-ui-button-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+}

--- a/packages/components/src/button/src/CrossButton.tsx
+++ b/packages/components/src/button/src/CrossButton.tsx
@@ -1,14 +1,18 @@
+import "./CrossButton.css";
+
 import { AbstractIconButtonProps, IconButton, InnerIconButton } from "./IconButton";
 import { ComponentProps, forwardRef } from "react";
 import { CrossMinorIcon } from "../../icons";
 import { OmitInternalProps, slot } from "../../shared";
+import { mergeClasses } from "@components/shared";
 
 export type InnerCrossButtonProps = Omit<AbstractIconButtonProps<"button">, "fluid" | "loading" | "onChange" | "type" | "variant">;
 
-export function InnerCrossButton({ forwardedRef, ...rest }: InnerCrossButtonProps) {
+export function InnerCrossButton({ className, forwardedRef, ...rest }: InnerCrossButtonProps) {
     return (
         <IconButton
             {...rest}
+            className={mergeClasses("o-ui-cross-button", className)}
             fill="alias-primary"
             ref={forwardedRef}
             variant="tertiary"

--- a/packages/components/src/button/src/CrossButton.tsx
+++ b/packages/components/src/button/src/CrossButton.tsx
@@ -3,8 +3,7 @@ import "./CrossButton.css";
 import { AbstractIconButtonProps, IconButton, InnerIconButton } from "./IconButton";
 import { ComponentProps, forwardRef } from "react";
 import { CrossMinorIcon } from "../../icons";
-import { OmitInternalProps, slot } from "../../shared";
-import { mergeClasses } from "@components/shared";
+import { OmitInternalProps, mergeClasses, slot } from "../../shared";
 
 export type InnerCrossButtonProps = Omit<AbstractIconButtonProps<"button">, "fluid" | "loading" | "onChange" | "type" | "variant">;
 


### PR DESCRIPTION
Issue:

## Summary

CrossButton Icon was too big. This is due to the fact that the new design calls for bigger icons in bigger buttons, this is not ideal for close buttons as they look wacky.

## What I did

Made sure that CrossButton iconSize is 20px.
