### PR TITLE
Heading Small Line Height Token value update

### DIFF
--- a/.changeset/poor-ligers-retire.md
+++ b/.changeset/poor-ligers-retire.md
@@ -1,0 +1,5 @@
+---
+"@orbit-ui/transition-components": patch
+---
+
+Fix for heading small line height token

--- a/packages/components/src/styling/src/theming/hopper-theme.css
+++ b/packages/components/src/styling/src/theming/hopper-theme.css
@@ -318,7 +318,7 @@
     --hop-heading-xs-font-weight: var(--hop-font-weight-410);
     --hop-heading-xs-font-size: var(--hop-font-size-160);
     --hop-heading-xs-font-family: var(--hop-font-family-primary);
-    --hop-heading-sm-line-height: var(--hop-line-height-1-50);
+    --hop-heading-sm-line-height: var(--hop-line-height-1-33);
     --hop-heading-sm-font-weight: var(--hop-font-weight-580);
     --hop-heading-sm-font-size: var(--hop-font-size-180);
     --hop-heading-sm-font-family: var(--hop-font-family-primary);


### PR DESCRIPTION
Issue:

## Summary

The heading-small-line-height value was using 1.5 instead 1.33

## What I did

Replaced the value.