### PR TITLE
updated neutral strong surface token in dark mode

### DIFF
--- a/.changeset/rare-boxes-yell.md
+++ b/.changeset/rare-boxes-yell.md
@@ -1,0 +1,5 @@
+---
+"@orbit-ui/transition-components": patch
+---
+
+Token update

--- a/packages/components/src/styling/src/theming/hopper-theme.css
+++ b/packages/components/src/styling/src/theming/hopper-theme.css
@@ -780,7 +780,7 @@
     --hop-neutral-border-disabled: var(--hop-rock-800);
     --hop-neutral-border-strong-hover: var(--hop-samoyed);
     --hop-neutral-border-strong: var(--hop-samoyed);
-    --hop-neutral-surface-strong: var(--hop-samoyed);
+    --hop-neutral-surface-strong: var(--hop-toad-25);
     --hop-neutral-surface-hover: var(--hop-rock-800);
     --hop-neutral-icon-disabled: var(--hop-rock-500);
     --hop-neutral-icon: var(--hop-rock-25);


### PR DESCRIPTION
Issue:

## Summary

https://github.com/gsoft-inc/wl-orbiter/issues/57

hop-neutral-surface-strong token should be Toad-25 in dark mode

## What I did

Replaced the value by the right one.