### PR TITLE
fix: DialogTrigger was setting the Dialog's zIndex to 1 by default

### DIFF
--- a/.changeset/slow-nails-hear.md
+++ b/.changeset/slow-nails-hear.md
@@ -1,0 +1,5 @@
+---
+"@orbit-ui/transition-components": patch
+---
+
+DialogTrigger's zIndex default value has been bumped from 1 to 10000 to better reflect the expected zIndex value of Dialogs

--- a/packages/components/src/dialog/src/DialogTrigger.tsx
+++ b/packages/components/src/dialog/src/DialogTrigger.tsx
@@ -54,7 +54,7 @@ export function InnerDialogTrigger({
     forwardedRef,
     onOpenChange,
     open: openProp,
-    zIndex = 1,
+    zIndex = 10000,
     ...rest
 }: InnerDialogTriggerProps) {
     const [isOpen, setIsOpen] = useControllableState(openProp, defaultOpen, false);


### PR DESCRIPTION
A dialog had a default zIndex of 10000, but the trigger was setting it to 1 by default. 

