### PR TITLE
Multiple Fixes

### DIFF
--- a/.changeset/fifty-waves-peel.md
+++ b/.changeset/fifty-waves-peel.md
@@ -1,0 +1,9 @@
+---
+"@orbit-ui/transition-components": minor
+---
+
+- Fixed TextArea doesn't honor the rows property
+- Fixed NumberInput component does not trigger onValueChange on Blur with null Value
+- Fixed Conflict between HTML table border property and Styled System border property in Table component
+- Fixed Switches don't handle the fluid props passed by the Form, resulting in forwarding fluid to a DOM element that doesn't accept the property
+- Removed console.log that were accidentally released

--- a/packages/components/src/listbox/src/ListboxOption.tsx
+++ b/packages/components/src/listbox/src/ListboxOption.tsx
@@ -129,7 +129,6 @@ export function InnerListboxOption({
 
     const labelId = text?.props?.id;
     const descriptionId = description?.props?.id;
-    console.log("endicon", endIcon);
 
     const optionMarkup = (
         <Box

--- a/packages/components/src/number-input/src/NumberInput.tsx
+++ b/packages/components/src/number-input/src/NumberInput.tsx
@@ -272,6 +272,8 @@ export function InnerNumberInput(props: InnerNumberInputProps) {
                     updateValue(event, max);
                 }
             }
+        } else {
+            updateValue(event, newValue);
         }
     };
 

--- a/packages/components/src/shared/src/types.ts
+++ b/packages/components/src/shared/src/types.ts
@@ -38,7 +38,7 @@ export interface InteractionProps {
     hover?: boolean;
 }
 
-export type StyledSystemOverlappingHtmlAttributes = "as" | "color" | "content" | "height" | "size" | "width" | "wrap";
+export type StyledSystemOverlappingHtmlAttributes = "as" | "color" | "content" | "height" | "size" | "width" | "wrap" | "border";
 
 export type StyledComponentProps<T extends ElementType> = StyledSystemProps & Omit<ComponentProps<T>, StyledSystemOverlappingHtmlAttributes>;
 

--- a/packages/components/src/switch/src/Switch.tsx
+++ b/packages/components/src/switch/src/Switch.tsx
@@ -86,7 +86,7 @@ export function InnerSwitch(props: InnerSwitchProps) {
     } = mergeProps(
         props,
         omitProps(toolbarProps, ["orientation"]),
-        fieldProps
+        omitProps(fieldProps, ["fluid"]),
     );
 
     if (isNil(children) && isNil(ariaLabel) && isNil(ariaLabelledBy)) {

--- a/packages/components/src/text-area/docs/TextArea.stories.mdx
+++ b/packages/components/src/text-area/docs/TextArea.stories.mdx
@@ -51,6 +51,20 @@ A textarea can be limited to a maximum number of rows.
     </Story>
 </Preview>
 
+
+### Rows
+
+A textarea can chose the number of rows to display.
+
+<Preview>
+    <Story name="rows">
+        <Inline>
+            <TextArea rows={8} placeholder="Why should you go to space?" />
+        </Inline>
+    </Story>
+</Preview>
+
+
 ### Disabled
 
 A textarea can be disabled.

--- a/packages/components/src/text-area/src/TextArea.css
+++ b/packages/components/src/text-area/src/TextArea.css
@@ -7,7 +7,6 @@
     /* Fixes a bug where Firefox adds one more row than the one specified. */
     overflow-x: hidden;
     padding: var(--hop-space-inset-squish-md);
-    min-height: 5rem;
     color: inherit;
     font-family: inherit;
     font-size: inherit;


### PR DESCRIPTION
Fixes https://github.com/gsoft-inc/wl-orbiter/issues/73 https://github.com/gsoft-inc/wl-orbiter/issues/59 https://github.com/gsoft-inc/wl-orbiter/issues/53 https://github.com/gsoft-inc/wl-orbiter/issues/52


- Fixed TextArea doesn't honor the rows property
- Fixed NumberInput component does not trigger onValueChange on Blur with null Value
- Fixed Conflict between HTML table border property and Styled System border property in Table component
- Fixed Switches don't handle the fluid props passed by the Form, resulting in forwarding fluid to a DOM element that doesn't accept the property
- Removed console.log that were accidentally released