### PR TITLE
Removed the "as" prop from the ThemeProvider. The ThemeProvider now creates 1 wrapping div instead of 2.

### DIFF
--- a/.changeset/nice-eagles-rush.md
+++ b/.changeset/nice-eagles-rush.md
@@ -1,0 +1,6 @@
+---
+"@orbit-ui/transition-components": minor
+"@workleap/orbiter-ui": minor
+---
+
+Removed the "as" prop from the ThemeProvider. The ThemeProvider now creates 1 wrapping div instead of 2.


### PR DESCRIPTION
Closes #79 