### PR TITLE
Modify the Typescript typings for the as function

### DIFF
--- a/.changeset/fresh-snails-press.md
+++ b/.changeset/fresh-snails-press.md
@@ -1,0 +1,5 @@
+---
+"@orbit-ui/transition-components": patch
+---
+
+Modify the Typescript typings for the as function

--- a/packages/components/src/shared/src/type-fest.ts
+++ b/packages/components/src/shared/src/type-fest.ts
@@ -12,8 +12,6 @@ type Except<ObjectType, KeysType extends keyof ObjectType> = {
     [KeyType in keyof ObjectType as Filter<KeyType, KeysType>]: ObjectType[KeyType];
 };
 
-type Extract<T, U> = T extends U ? T : never;
-
 type Merge_<FirstType, SecondType> = Except<FirstType, Extract<keyof FirstType, keyof SecondType>> & SecondType;
 
 type Simplify<T> = { [KeyType in keyof T]: T[KeyType] };


### PR DESCRIPTION
When copying the typings from type-fest, i copied by accident a typing coming from typescript itself, `Extract`. This seems to be causing issues, so i removed this type and it fixed the issues