### PR TITLE
hotfix/input-focus-style

### DIFF
--- a/packages/components/src/checkbox/src/Checkbox.css
+++ b/packages/components/src/checkbox/src/Checkbox.css
@@ -45,7 +45,7 @@
     bottom: -1px;
     display: block;
     position: absolute;
-    box-shadow: 0 0 0 0.12rem var(--hop-neutral-surface), 0 0 0 0.219rem var(--hop-primary-border-focus);
+    box-shadow: 0 0 0 0.125rem var(--hop-neutral-surface), 0 0 0 0.25rem var(--hop-primary-border-focus);
     border-radius: var(--_checkbox-border-radius);
     transition: var(--o-ui-focus-ring-transition);
 }

--- a/packages/components/src/date-input/src/DateRangeInput.css
+++ b/packages/components/src/date-input/src/DateRangeInput.css
@@ -31,7 +31,7 @@
 .o-ui-date-range-input-focus:not(.o-ui-date-range-input-disabled) {
     --o-ui-date-range-input-border-color: var(--hop-neutral-border-active);
     background-color: var(--hop-neutral-surface);
-    box-shadow: 0 0 0 0.12rem var(--hop-neutral-surface), 0 0 0 0.219rem var(--hop-primary-border-focus);
+    box-shadow: 0 0 0 0.125rem var(--hop-neutral-surface), 0 0 0 0.25rem var(--hop-primary-border-focus);
 }
 
 /* STATES | FOCUS / INVALID */

--- a/packages/components/src/input/src/Input.css
+++ b/packages/components/src/input/src/Input.css
@@ -170,7 +170,7 @@
 .o-ui-input-focus:not(.o-ui-input-disabled):not(.o-ui-has-button-disabled) {
     --o-ui-input-border-color: var(--hop-neutral-border-active);
     --o-ui-input-background-color: var(--hop-neutral-surface);
-    box-shadow: 0 0 0 0.12rem var(--hop-neutral-surface), 0 0 0 0.219rem var(--hop-primary-border-focus);
+    box-shadow: 0 0 0 0.125rem var(--hop-neutral-surface), 0 0 0 0.25rem var(--hop-primary-border-focus);
     outline: transparent;
 }
 

--- a/packages/components/src/radio/src/Radio.css
+++ b/packages/components/src/radio/src/Radio.css
@@ -92,7 +92,7 @@
     inset: -1px;
     display: block;
     position: absolute;
-    box-shadow: 0 0 0 0.12rem var(--hop-neutral-surface), 0 0 0 0.219rem var(--hop-primary-border-focus);
+    box-shadow: 0 0 0 0.125rem var(--hop-neutral-surface), 0 0 0 0.25rem var(--hop-primary-border-focus);
     border-radius: var(--hop-shape-circle);
     transition: var(--o-ui-focus-ring-transition);
 }

--- a/packages/components/src/select/src/Select.css
+++ b/packages/components/src/select/src/Select.css
@@ -100,7 +100,7 @@
 .o-ui-select-trigger-ghost:not([disabled]):focus-visible {
     --o-ui-select-icon-color: var(--hop-neutral-icon-hover);
     background: var(--hop-neutral-surface-hover);
-    box-shadow: 0 0 0 0.12rem var(--hop-neutral-surface), 0 0 0 0.219rem var(--hop-primary-border-focus);
+    box-shadow: 0 0 0 0.125rem var(--hop-neutral-surface), 0 0 0 0.25rem var(--hop-primary-border-focus);
 }
 
 .o-ui-select-trigger-ghost:not([disabled])[aria-expanded="true"] {
@@ -166,7 +166,7 @@
     --o-ui-select-icon-color: var(--hop-neutral-icon-hover);
     background: var(--hop-neutral-surface-hover);
     border-color: var(--hop-neutral-border-hover);
-    box-shadow: 0 0 0 0.12rem var(--hop-neutral-surface), 0 0 0 0.219rem var(--hop-primary-border-focus);
+    box-shadow: 0 0 0 0.125rem var(--hop-neutral-surface), 0 0 0 0.25rem var(--hop-primary-border-focus);
     color: var(--hop-neutral-text-hover);
 }
 

--- a/packages/components/src/switch/src/Switch.css
+++ b/packages/components/src/switch/src/Switch.css
@@ -89,7 +89,7 @@
 .o-ui-switch-focus:not(.o-ui-switch-disabled) .o-ui-switch-control {
     background-color: var(--o-ui-switch-background-focus);
     border-color: var(--o-ui-switch-border-focus);
-    box-shadow: 0 0 0 0.12rem var(--hop-neutral-surface), 0 0 0 0.219rem var(--hop-primary-border-focus);
+    box-shadow: 0 0 0 0.125rem var(--hop-neutral-surface), 0 0 0 0.25rem var(--hop-primary-border-focus);
 }
 
 .o-ui-switch input[type="checkbox"]:focus-visible + .o-ui-switch-control::before,


### PR DESCRIPTION
Focus style in Firefox was rounded to the lower pixel (3.5 was rounded to 3, where it was rounded to 4 in Chrome) this fix make sure 4 is the right used vaiue.