### PR TITLE
Feature/177

### DIFF
--- a/.changeset/healthy-worms-nail.md
+++ b/.changeset/healthy-worms-nail.md
@@ -1,0 +1,5 @@
+---
+"@orbit-ui/transition-components": minor
+---
+
+Added xs size for tag

--- a/packages/components/src/tag/docs/Tag.stories.mdx
+++ b/packages/components/src/tag/docs/Tag.stories.mdx
@@ -143,6 +143,7 @@ A tag can vary in size. When a lot of tags can be seen side by side, prefer the 
 <Preview>
     <Story name="size">
         <Inline alignY="center">
+            <Tag size="xs">Falcon 9</Tag>
             <Tag size="sm">Falcon 9</Tag>
             <Tag>Falcon 9</Tag>
         </Inline>

--- a/packages/components/src/tag/src/Tag.css
+++ b/packages/components/src/tag/src/Tag.css
@@ -51,7 +51,7 @@ a:not([disabled]).o-ui-tag.o-ui-tag-focus:after {
 /* SIZE */
 /* SIZE | XSMALL */
 .o-ui-tag-xs {
-    min-height: 1rem;
+    min-height: 1.25rem;
     padding: 0 var(--o-ui-padding-xs);
 }
 

--- a/packages/components/src/tag/src/Tag.css
+++ b/packages/components/src/tag/src/Tag.css
@@ -1,4 +1,5 @@
 .o-ui-tag {
+    --o-ui-padding-xs: var(--hop-space-inset-sm);
     --o-ui-padding-sm: var(--hop-space-inset-md);
     --o-ui-padding-md: var(--hop-space-inset-md);
     --o-ui-tag-border-size: 1px;
@@ -48,6 +49,12 @@ a:not([disabled]).o-ui-tag.o-ui-tag-focus:after {
 }
 
 /* SIZE */
+/* SIZE | XSMALL */
+.o-ui-tag-xs {
+    min-height: 1rem;
+    padding: 0 var(--o-ui-padding-xs);
+}
+
 /* SIZE | SMALL */
 .o-ui-tag-sm {
     min-height: 1.5rem;

--- a/packages/components/src/tag/src/Tag.tsx
+++ b/packages/components/src/tag/src/Tag.tsx
@@ -45,7 +45,7 @@ export interface InnerTagProps extends InternalProps, InteractionProps, StyledCo
 /* eslint-disable sort-keys, sort-keys-fix/sort-keys-fix */
 const textSize = createSizeAdapter({
     "xs": "xs",
-    "sm": "sm",
+    "sm": "xs",
     "md": "sm"
 });
 

--- a/packages/components/src/tag/src/Tag.tsx
+++ b/packages/components/src/tag/src/Tag.tsx
@@ -31,7 +31,7 @@ export interface InnerTagProps extends InternalProps, InteractionProps, StyledCo
     /**
      * A tag can vary in size.
      */
-    size?: ResponsiveProp<"sm" | "md">;
+    size?: ResponsiveProp<"xs" | "sm" | "md">;
     /**
      * Whether or not the tag should display as "valid" or "invalid".
      */
@@ -44,11 +44,13 @@ export interface InnerTagProps extends InternalProps, InteractionProps, StyledCo
 
 /* eslint-disable sort-keys, sort-keys-fix/sort-keys-fix */
 const textSize = createSizeAdapter({
+    "xs": "xs",
     "sm": "sm",
     "md": "sm"
 });
 
 const embedIconButton = createEmbeddableAdapter({
+    "xs": "2xs",
     "sm": "2xs",
     "md": "2xs"
 });

--- a/packages/components/src/tag/tests/chromatic/TagList.stories.tsx
+++ b/packages/components/src/tag/tests/chromatic/TagList.stories.tsx
@@ -29,6 +29,11 @@ export const Default: TagListStory = {
                 <Item key="gemini">Gemini Program</Item>
                 <Item key="apollo">Apollo Program</Item>
             </TagList>
+            <TagList size="xs">
+                <Item key="mercury">Mercury Program</Item>
+                <Item key="gemini">Gemini Program</Item>
+                <Item key="apollo">Apollo Program</Item>
+            </TagList>
         </Stack>
     )
 };
@@ -97,12 +102,12 @@ export const WithClearButton: TagListStory = {
     storyName: "with clear button",
     render: () => (
         <Stack>
-            <TagList onClear={() => {}}>
+            <TagList onClear={() => { }}>
                 <Item key="mercury">Mercury Program</Item>
                 <Item key="gemini">Gemini Program</Item>
                 <Item key="apollo">Apollo Program</Item>
             </TagList>
-            <TagList size="sm" onClear={() => {}}>
+            <TagList size="sm" onClear={() => { }}>
                 <Item key="mercury">Mercury Program</Item>
                 <Item key="gemini">Gemini Program</Item>
                 <Item key="apollo">Apollo Program</Item>
@@ -114,7 +119,7 @@ export const WithClearButton: TagListStory = {
 export const WithClearButtonEmpty: TagListStory = {
     storyName: "with clear button & empty",
     render: () => (
-        <TagList onClear={() => {}}>
+        <TagList onClear={() => { }}>
         </TagList>
     )
 };
@@ -128,7 +133,7 @@ export const Readonly: TagListStory = {
                 <Item key="gemini">Gemini Program</Item>
                 <Item key="apollo">Apollo Program</Item>
             </TagList>
-            <TagList readOnly onClear={() => {}}>
+            <TagList readOnly onClear={() => { }}>
                 <Item key="mercury">Mercury Program</Item>
                 <Item key="gemini">Gemini Program</Item>
                 <Item key="apollo">Apollo Program</Item>
@@ -146,7 +151,7 @@ export const Validation: TagListStory = {
                 <Item key="gemini">Gemini Program</Item>
                 <Item key="apollo">Apollo Program</Item>
             </TagList>
-            <TagList readOnly onClear={() => {}} validationState="invalid">
+            <TagList readOnly onClear={() => { }} validationState="invalid">
                 <Item key="mercury">Mercury Program</Item>
                 <Item key="gemini">Gemini Program</Item>
                 <Item key="apollo">Apollo Program</Item>
@@ -181,7 +186,7 @@ export const MultipleRows: TagListStory = {
                 </TagList>
             </Div>
             <Div width="24rem">
-                <TagList onClear={() => {}}>
+                <TagList onClear={() => { }}>
                     <Item key="mercury">Mercury Program</Item>
                     <Item key="gemini">Gemini Program</Item>
                     <Item key="apollo">Apollo Program</Item>

--- a/packages/components/src/tag/tests/chromatic/createTagTestSuite.jsx
+++ b/packages/components/src/tag/tests/chromatic/createTagTestSuite.jsx
@@ -18,6 +18,7 @@ export function createTagTestSuite(element, stories) {
         .add("default", () =>
             <Stack>
                 <Inline alignY="end">
+                    <Tag size="xs" element={element}>Falcon 9</Tag>
                     <Tag size="sm" element={element}>Falcon 9</Tag>
                     <Tag element={element}>Falcon 9</Tag>
                 </Inline>
@@ -30,6 +31,10 @@ export function createTagTestSuite(element, stories) {
         .add("icon", () =>
             <Stack>
                 <Inline alignY="end">
+                    <Tag size="xs" element={element}>
+                        <SparklesIcon />
+                        <Text>Falcon 9</Text>
+                    </Tag>
                     <Tag size="sm" element={element}>
                         <SparklesIcon />
                         <Text>Falcon 9</Text>
@@ -40,6 +45,12 @@ export function createTagTestSuite(element, stories) {
                     </Tag>
                 </Inline>
                 <Inline alignY="end">
+                    <Tag size="xs" element={element}>
+                        <IconList>
+                            <SparklesIcon /><SparklesIcon /><SparklesIcon />
+                        </IconList>
+                        <Text>Falcon 9</Text>
+                    </Tag>
                     <Tag size="sm" element={element}>
                         <IconList>
                             <SparklesIcon /><SparklesIcon /><SparklesIcon />
@@ -64,6 +75,12 @@ export function createTagTestSuite(element, stories) {
                     </Tag>
                 </Div>
                 <Inline alignY="end">
+                    <Tag size="xs" element={element}>
+                        <Text>Falcon 9</Text>
+                        <IconList slot="end-icon">
+                            <SparklesIcon /><SparklesIcon /><SparklesIcon />
+                        </IconList>
+                    </Tag>
                     <Tag size="sm" element={element}>
                         <Text>Falcon 9</Text>
                         <IconList slot="end-icon">
@@ -110,6 +127,10 @@ export function createTagTestSuite(element, stories) {
         .add("dot", () =>
             <Stack>
                 <Inline alignY="end">
+                    <Tag size="xs" element={element}>
+                        <Dot color="primary" />
+                        <Text>Falcon 9</Text>
+                    </Tag>
                     <Tag size="sm" element={element}>
                         <Dot color="primary" />
                         <Text>Falcon 9</Text>
@@ -134,6 +155,10 @@ export function createTagTestSuite(element, stories) {
         .add("avatar", () =>
             <Stack>
                 <Inline alignY="end">
+                    <Tag size="xs" element={element}>
+                        <Avatar name="Alan Shepard" />
+                        <Text>Alan Shepard</Text>
+                    </Tag>
                     <Tag size="sm" element={element}>
                         <Avatar name="Alan Shepard" />
                         <Text>Alan Shepard</Text>
@@ -183,6 +208,10 @@ export function createTagTestSuite(element, stories) {
                 <Div width="10%">
                     <Stack>
                         <Inline>
+                            <Tag fluid size="xs" element={element}>
+                                <Dot color="primary" />
+                                <Text>Falcon 9</Text>
+                            </Tag>
                             <Tag fluid size="sm" element={element}>
                                 <Dot color="primary" />
                                 <Text>Falcon 9</Text>
@@ -202,6 +231,10 @@ export function createTagTestSuite(element, stories) {
                             </Tag>
                         </Inline>
                         <Inline>
+                            <Tag size="xs" fluid element={element}>
+                                <SparklesIcon />
+                                <Text>Falcon 9</Text>
+                            </Tag>
                             <Tag size="sm" fluid element={element}>
                                 <SparklesIcon />
                                 <Text>Falcon 9</Text>
@@ -219,6 +252,10 @@ export function createTagTestSuite(element, stories) {
         .add("counter", () =>
             <Stack>
                 <Inline alignY="end">
+                    <Tag size="xs" element={element}>
+                        <Text>Falcon 9</Text>
+                        <Counter variant="divider">60</Counter>
+                    </Tag>
                     <Tag size="sm" element={element}>
                         <Text>Falcon 9</Text>
                         <Counter variant="divider">60</Counter>
@@ -243,6 +280,9 @@ export function createTagTestSuite(element, stories) {
         .add("remove button", () =>
             <Stack>
                 <Inline alignY="end">
+                    <Tag size="xs" onRemove={() => {}} element={element}>
+                        Falcon 9
+                    </Tag>
                     <Tag size="sm" onRemove={() => {}} element={element}>
                         Falcon 9
                     </Tag>
@@ -263,6 +303,9 @@ export function createTagTestSuite(element, stories) {
         .add("validation", () =>
             <Stack>
                 <Inline alignY="end">
+                    <Tag size="xs" onRemove={() => {}} element={element} validationState="invalid">
+                        Falcon 9
+                    </Tag>
                     <Tag size="sm" onRemove={() => {}} element={element} validationState="invalid">
                         Falcon 9
                     </Tag>


### PR DESCRIPTION
In order to match Hopper look of tags, a new size has been added. To prevent a breaking change, the new added size is xs, this will match with Hopper sm size.

- `xs` tag size added that maps to `sm` in Hopper.
- Adjusted font-size of small size tag.