### PR TITLE
Fix: [DS-270] counter alignment inside tag

### DIFF
--- a/.changeset/wicked-ants-accept.md
+++ b/.changeset/wicked-ants-accept.md
@@ -1,0 +1,5 @@
+---
+"@workleap/orbiter-ui": patch
+---
+
+Made sure counter is aligned properly inside Tag by match the font-size.

--- a/packages/components/src/counter/src/Counter.css
+++ b/packages/components/src/counter/src/Counter.css
@@ -27,12 +27,14 @@
 
 /* BASIC */
 .o-ui-counter-basic {
-    display: inline-block;
+    align-items: center;
+    display: inline-flex;
 }
 
 /* DIVIDER */
 .o-ui-counter-divider {
-    display: inline-block;
+    align-items: center;
+    display: inline-flex;
     position: relative;
     padding-left: var(--hop-space-inset-sm);
 }

--- a/packages/components/src/tag/src/Tag.tsx
+++ b/packages/components/src/tag/src/Tag.tsx
@@ -48,6 +48,11 @@ const textSize = createSizeAdapter({
     "md": "sm"
 });
 
+const counterSize = createSizeAdapter({
+    "sm": "xs",
+    "md": "sm"
+});
+
 const embedIconButton = createEmbeddableAdapter({
     "sm": "2xs",
     "md": "2xs"
@@ -93,7 +98,7 @@ export function InnerTag(props: InnerTagProps) {
             color: "inherit",
             disabled,
             pushed: true,
-            size: sizeValue
+            size: counterSize(sizeValue)
         },
         dot: {
             className: "o-ui-tag-dot",


### PR DESCRIPTION

## Summary

The counter was misaligned inside the size sm tag.

## What I did

Changed the size of the counter inside a Tag to match the tag's font-size, which fixes the alignment issue.

## How to test

Just go to the Tag chromatic tests and look at the Counter story.
