### PR TITLE
[DS-288] Autocomplete fix

### DIFF
--- a/.changeset/tidy-tigers-provide.md
+++ b/.changeset/tidy-tigers-provide.md
@@ -1,0 +1,5 @@
+---
+"@workleap/orbiter-ui": patch
+---
+
+Add boundaryElement to Autocomplete and Listbox

--- a/packages/components/src/autocomplete/src/Autocomplete.tsx
+++ b/packages/components/src/autocomplete/src/Autocomplete.tsx
@@ -31,6 +31,10 @@ const DefaultElement = "input";
 
 export interface InnerAutocompleteProps extends PopupProps, Omit<AbstractInputProps<typeof DefaultElement>, "zIndex"> {
     /**
+     * This describes the area that the element will be checked for overflow relative to.
+     */
+    boundaryElement?: HTMLElement;
+    /**
      * React children.
      */
     children: ReactNode;
@@ -110,6 +114,7 @@ export function InnerAutocomplete(props: InnerAutocompleteProps) {
         "aria-labelledby": ariaLabelledBy,
         as = DefaultElement,
         autoFocus,
+        boundaryElement,
         children,
         clearOnSelect,
         defaultOpen,
@@ -369,6 +374,7 @@ export function InnerAutocomplete(props: InnerAutocompleteProps) {
             // An autocomplete doesn't support any persisted selected keys.
             aria-label={ariaLabel}
             aria-labelledby={isNil(ariaLabel) ? ariaLabelledBy ?? triggerId : undefined}
+            boundaryElement={boundaryElement}
             className="o-ui-autocomplete-listbox"
             fluid
             focusOnHover

--- a/packages/components/src/collection/src/useScrollableCollection.ts
+++ b/packages/components/src/collection/src/useScrollableCollection.ts
@@ -4,6 +4,7 @@ import { isNil, useIsomorphicLayoutEffect } from "../../shared";
 
 interface UseScrollableCollectionOptions {
     borderHeight?: number;
+    boundaryElement?: HTMLElement;
     disabled?: boolean;
     dividerSelector?: string;
     itemSelector?: string;
@@ -34,6 +35,7 @@ function getOuterHeight(element: HTMLElement) {
 export function useScrollableCollection(containerRef: RefObject<Element>, nodes: CollectionNode[],
     {
         borderHeight = 0,
+        boundaryElement,
         disabled,
         dividerSelector,
         itemSelector,
@@ -63,6 +65,20 @@ export function useScrollableCollection(containerRef: RefObject<Element>, nodes:
 
                     height += outerHeight;
                 });
+
+                if (boundaryElement) {
+                    const { offsetHeight: boundaryHeight } = boundaryElement;
+
+                    const { y: containerY } = containerRef.current.getBoundingClientRect();
+
+                    // If the container and direction is bottom is overflowing the boundary, adjust the height
+                    if (height + containerY > boundaryHeight) {
+                        height = boundaryHeight - containerY;
+                        // If the container and direction is top is overflowing the boundary, adjust the height
+                    } else if (containerY < 0) {
+                        height = height + containerY;
+                    }
+                }
 
                 setCollectionHeight(`${height}px`);
             }

--- a/packages/components/src/collection/src/useScrollableCollection.ts
+++ b/packages/components/src/collection/src/useScrollableCollection.ts
@@ -71,10 +71,10 @@ export function useScrollableCollection(containerRef: RefObject<Element>, nodes:
 
                     const { y: containerY } = containerRef.current.getBoundingClientRect();
 
-                    // If the container and direction is bottom is overflowing the boundary, adjust the height
+                    // If the direction is `bottom` and the container is overflowing the boundary, adjust the height.
                     if (height + containerY > boundaryHeight) {
                         height = boundaryHeight - containerY;
-                        // If the container and direction is top is overflowing the boundary, adjust the height
+                        // If the direction is `top` and the container is overflowing the boundary, adjust the height
                     } else if (containerY < 0) {
                         height = height + containerY;
                     }

--- a/packages/components/src/listbox/src/Listbox.tsx
+++ b/packages/components/src/listbox/src/Listbox.tsx
@@ -48,6 +48,10 @@ export interface InnerListboxProps extends InternalProps, StyledComponentProps<t
      */
     autoFocusTarget?: string;
     /**
+     * This describes the area that the element will be checked for overflow relative to.
+     */
+    boundaryElement?: HTMLElement;
+    /**
      * The initial value of `selectedKeys` when uncontrolled.
      */
     defaultSelectedKeys?: string[];
@@ -161,6 +165,7 @@ export function InnerListbox({
     autoFocus,
     // TODO: Could it be removed now that useImperativeHandle expose the focus? If yes, also remove from Menu (which might not event need the useImperativeHandle)
     autoFocusTarget,
+    boundaryElement,
     children,
     defaultSelectedKeys,
     fluid,
@@ -366,6 +371,7 @@ export function InnerListbox({
 
     const scrollableProps = useScrollableCollection(containerRef, nodes, {
         borderHeight: 2,
+        boundaryElement,
         itemSelector: ".o-ui-listbox-option",
         maxHeight: 12 * ListboxItemHeight + 2 * ListboxItemHeight,
         paddingHeight: 16,


### PR DESCRIPTION
Issue: Autocomplete in a Modal would overflow

## Summary

Fix the issue where an Autocomplete in a Modal would overflow

If we're using the autocomplete in a Modal, the user will have to add the Overlay element of the modal to boundaryElement.

## What I did

Added the option to add a boundaryElement to the Autocomplete and Listbox component. 

## How to test

- Is this testable with Jest or Chromatic screenshots? no

- Does this need an update to the documentation? maybe?

If your answer is yes to any of these, please make sure to include it in your PR.

I tested by adding the boundary directly to the Listbox from the Autocomplete when it's inside a modal.

![Screenshot 2024-09-23 at 10 01 27 AM](https://github.com/user-attachments/assets/0ff116cc-a85e-446d-82e1-37609030a509)
