### PR TITLE
alignment between hopper and orbiter

### DIFF
--- a/packages/components/src/button/src/ButtonGroup.tsx
+++ b/packages/components/src/button/src/ButtonGroup.tsx
@@ -34,7 +34,7 @@ export function InnerButtonGroup(props: InnerButtonGroupProps) {
     const [fieldProps, isInField] = useFieldInputProps();
 
     const {
-        align,
+        align = "start",
         as = DefaultElement,
         children,
         disabled,
@@ -57,7 +57,7 @@ export function InnerButtonGroup(props: InnerButtonGroupProps) {
             {...mergeProps(
                 rest,
                 {
-                    align,
+                    align: orientation === "vertical" ? "center" : align,
                     as,
                     className: cssModule(
                         "o-ui-button-group",

--- a/packages/components/src/dialog/src/Dialog.css
+++ b/packages/components/src/dialog/src/Dialog.css
@@ -139,7 +139,6 @@
 /* DIALOG | FOOTER SECTION | BUTTONS */
 .o-ui-dialog-button,
 .o-ui-dialog-button-group {
-    justify-content: flex-end;
     margin-left: auto;
 }
 

--- a/packages/components/src/dialog/src/Dialog.tsx
+++ b/packages/components/src/dialog/src/Dialog.tsx
@@ -222,7 +222,8 @@ export function InnerDialog({
             className: "o-ui-dialog-button"
         },
         "button-group": {
-            className: "o-ui-dialog-button-group"
+            className: "o-ui-dialog-button-group",
+            justifyContent: "end"
         },
         content: {
             as: Text,


### PR DESCRIPTION
In order to ease the transition between Hopper and Orbiter some changes need to be made.

- Since the Group component is used, rightfully, and sets an align-items center by default, I had to set it to start on the buttonGroup.
- A dialog buttonGroup should be aligned at the end, It's now being done via styleProps instead of CSS.
- When a buttonGroup orientation is vertical, it's alignment should be center.