### PR TITLE
[DS-379] Make heading optional in Popover

### DIFF
--- a/.changeset/angry-panthers-try.md
+++ b/.changeset/angry-panthers-try.md
@@ -1,0 +1,5 @@
+---
+"@workleap/orbiter-ui": patch
+---
+
+Heading is now optional in Popover

--- a/packages/components/src/popover/src/Popover.tsx
+++ b/packages/components/src/popover/src/Popover.tsx
@@ -92,7 +92,7 @@ export function InnerPopover({
 
     const { button, "button-group": buttonGroup, content, footer, heading } = useSlots(children, useMemo(() => ({
         _: {
-            required: ["heading", "content"]
+            required: ["content"]
         },
         button: {
             className: "o-ui-popover-button",

--- a/packages/components/src/popover/tests/chromatic/Popover.stories.tsx
+++ b/packages/components/src/popover/tests/chromatic/Popover.stories.tsx
@@ -207,3 +207,12 @@ export const Style: PopoverStory = {
         </Popover>
     )
 };
+
+export const NoHeading: PopoverStory = {
+    storyName: "no heading",
+    render: () => (
+        <Popover>
+            <Content>SpaceX designs, manufactures, and launches the world's most advanced rockets and spacecraft.</Content>
+        </Popover>
+    )
+};


### PR DESCRIPTION
Issue: https://workleap.atlassian.net/browse/DS-379

## Summary

Make Heading optional in Popover

## What I did

Remove heading from required slot and added a chromatic test

## How to test

- Is this testable with Jest or Chromatic screenshots? yes

![image](https://github.com/user-attachments/assets/affbb817-abb0-40ac-924a-07cba2d909e1)