### PR TITLE
[DS-354] Wrap text instead of overflowing

### DIFF
--- a/.changeset/light-carrots-relate.md
+++ b/.changeset/light-carrots-relate.md
@@ -1,0 +1,5 @@
+---
+"@workleap/orbiter-ui": patch
+---
+
+Switch, Checkbox and Radio label will now wrap instead of having an ellipsis by default

--- a/packages/components/src/checkbox/src/Checkbox.css
+++ b/packages/components/src/checkbox/src/Checkbox.css
@@ -98,10 +98,6 @@
 /* CONTENT | LABEL */
 .o-ui-checkbox-label {
     margin-left: var(--hop-space-inline-sm);
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    display: inline;
 }
 
 /* CONTENT | LABEL | REVERSE */

--- a/packages/components/src/radio/src/Radio.css
+++ b/packages/components/src/radio/src/Radio.css
@@ -51,9 +51,6 @@
 /* CONTENT | LABEL */
 .o-ui-radio-label {
     margin-left: var(--hop-space-inline-sm);
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
 }
 
 /* CONTENT | LABEL | REVERSE */

--- a/packages/components/src/switch/src/Switch.css
+++ b/packages/components/src/switch/src/Switch.css
@@ -43,10 +43,6 @@
 .o-ui-switch-label {
     grid-area: label;
     margin-left: var(--hop-space-inline-sm);
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    display: inline;
 }
 
 /* LABEL | REVERSE */


### PR DESCRIPTION
Issue: https://workleap.atlassian.net/browse/DS-354

## Summary

Radio, Checkbox and Switch labels had their overflow hidden with an ellipsis by default. Default behavior should be to wrap instead. We'll let the users add the ellipsis themselves by overidding the CSS when needed.

## What I did

Remove the default ellipsis behavior for Radio, Checkbox and Switch.

## How to test

- Is this testable with Jest or Chromatic screenshots? yes