### PR TITLE
[DS-354] Align Checkbox, Radio and Switch with the top line of text

### DIFF
--- a/.changeset/thick-insects-lie.md
+++ b/.changeset/thick-insects-lie.md
@@ -1,0 +1,5 @@
+---
+"@workleap/orbiter-ui": patch
+---
+
+Align Checkbox, Switch and Radio to top instead of centering

--- a/packages/components/src/checkbox/src/Checkbox.css
+++ b/packages/components/src/checkbox/src/Checkbox.css
@@ -3,6 +3,7 @@
 }
 
 .o-ui-checkbox {
+    --_checkbox-size: 1.5rem;
     outline: transparent;
     display: inline-flex;
     align-items: flex-start;
@@ -19,7 +20,6 @@
 
 /* BOX */
 .o-ui-checkbox-box {
-    --_checkbox-size: 1.5rem;
     --_checkbox-border-radius: var(--hop-shape-rounded-sm);
     --_checkbox-border-color: var(--hop-neutral-border);
     --_checkbox-background-color: var(--hop-neutral-surface);
@@ -206,7 +206,7 @@
 /* SIZING */
 /* SIZING | SMALL */
 /* SIZING | SMALL | LABEL */
-.o-ui-checkbox-sm .o-ui-checkbox-box {
+.o-ui-checkbox-sm {
     --_checkbox-size: 1rem;
 }
 

--- a/packages/components/src/checkbox/src/Checkbox.css
+++ b/packages/components/src/checkbox/src/Checkbox.css
@@ -4,8 +4,9 @@
 
 .o-ui-checkbox {
     outline: transparent;
-    display: inline-flex;
-    align-items: center;
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
     cursor: pointer;
     color: var(--hop-neutral-text);
     line-height: var(--hop-body-sm-line-height);
@@ -97,6 +98,7 @@
 
 /* CONTENT | LABEL */
 .o-ui-checkbox-label {
+    margin-block-start: calc((1.5rem - (var(--hop-body-md-line-height) * var(--hop-body-md-font-size))) / 2);
     margin-left: var(--hop-space-inline-sm);
 }
 
@@ -208,6 +210,10 @@
 .o-ui-checkbox-sm .o-ui-checkbox-box:before {
     width: var(--_checkbox-size);
     height: var(--_checkbox-size);
+}
+
+.o-ui-checkbox-sm .o-ui-checkbox-label {
+    margin-block-start: calc((1rem - (var(--hop-body-sm-line-height) * var(--hop-body-sm-font-size))) / 2);
 }
 
 /* SIZING | SMALL | BOX | CHECKED */

--- a/packages/components/src/checkbox/src/Checkbox.css
+++ b/packages/components/src/checkbox/src/Checkbox.css
@@ -4,7 +4,7 @@
 
 .o-ui-checkbox {
     outline: transparent;
-    display: flex;
+    display: inline-flex;
     align-items: flex-start;
     justify-content: flex-start;
     cursor: pointer;

--- a/packages/components/src/checkbox/src/Checkbox.css
+++ b/packages/components/src/checkbox/src/Checkbox.css
@@ -98,8 +98,11 @@
 
 /* CONTENT | LABEL */
 .o-ui-checkbox-label {
-    margin-block-start: calc((1.5rem - (var(--hop-body-md-line-height) * var(--hop-body-md-font-size))) / 2);
     margin-left: var(--hop-space-inline-sm);
+}
+
+.o-ui-checkbox-counter, .o-ui-checkbox-label {
+    margin-top: calc((var(--_checkbox-size) - (var(--hop-body-md-line-height) * var(--hop-body-md-font-size))) / 2);
 }
 
 /* CONTENT | LABEL | REVERSE */
@@ -212,8 +215,9 @@
     height: var(--_checkbox-size);
 }
 
-.o-ui-checkbox-sm .o-ui-checkbox-label {
-    margin-block-start: calc((1rem - (var(--hop-body-sm-line-height) * var(--hop-body-sm-font-size))) / 2);
+.o-ui-checkbox-sm .o-ui-checkbox-label,
+.o-ui-checkbox-sm .o-ui-checkbox-counter {
+    margin-top: calc((var(--_checkbox-size) - (var(--hop-body-sm-line-height) * var(--hop-body-sm-font-size))) / 2);
 }
 
 /* SIZING | SMALL | BOX | CHECKED */

--- a/packages/components/src/radio/src/Radio.css
+++ b/packages/components/src/radio/src/Radio.css
@@ -1,7 +1,7 @@
 .o-ui-radio {
     --o-ui-radio-background-color: var(--hop-neutral-icon-selected);
     --o-ui-radio-border-color: var(--hop-neutral-border);
-    display: flex;
+    display: inline-flex;
     align-items: flex-start;
     justify-content: flex-start;
     cursor: pointer;
@@ -13,11 +13,10 @@
 
 /* BUTTON */
 .o-ui-radio-button {
-    align-self: baseline;
+    display: inline-block;
     background-color: var(--o-ui-radio-background-color);
     border-radius: var(--hop-shape-circle);
     border: 1px solid var(--o-ui-radio-border-color);
-    margin-top: 1.5px;
     position: relative;
     width: 1.5rem;
     height: 1.5rem;
@@ -42,7 +41,6 @@
 
 /* BUTTON | SMALL */
 .o-ui-radio-sm .o-ui-radio-button {
-    margin-top: 2px;
     width: 1rem;
     height: 1rem;
 }

--- a/packages/components/src/radio/src/Radio.css
+++ b/packages/components/src/radio/src/Radio.css
@@ -1,8 +1,9 @@
 .o-ui-radio {
     --o-ui-radio-background-color: var(--hop-neutral-icon-selected);
     --o-ui-radio-border-color: var(--hop-neutral-border);
-    display: inline-flex;
-    align-items: center;
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
     cursor: pointer;
     max-width: 100%;
     width: max-content;
@@ -12,10 +13,11 @@
 
 /* BUTTON */
 .o-ui-radio-button {
-    display: inline-block;
+    align-self: baseline;
     background-color: var(--o-ui-radio-background-color);
     border-radius: var(--hop-shape-circle);
     border: 1px solid var(--o-ui-radio-border-color);
+    margin-top: 1.5px;
     position: relative;
     width: 1.5rem;
     height: 1.5rem;
@@ -40,6 +42,7 @@
 
 /* BUTTON | SMALL */
 .o-ui-radio-sm .o-ui-radio-button {
+    margin-top: 2px;
     width: 1rem;
     height: 1rem;
 }
@@ -48,8 +51,9 @@
     --o-ui-radio-button-size: 0.5rem;
 }
 
-/* CONTENT | LABEL */
+/* CONTENT | LABEL | SMALL */
 .o-ui-radio-label {
+    margin-block-start: calc((1.5rem - (var(--hop-body-md-line-height) * var(--hop-body-md-font-size))) / 2);
     margin-left: var(--hop-space-inline-sm);
 }
 
@@ -57,6 +61,11 @@
 .o-ui-radio-reverse .o-ui-radio-label {
     margin-left: 0;
     margin-right: var(--hop-space-inline-sm);
+}
+
+/* CONTENT | LABEL | SMALL */
+.o-ui-radio-sm .o-ui-radio-label {
+    margin-block-start: calc((1rem - (var(--hop-body-sm-line-height) * var(--hop-body-sm-font-size))) / 2);
 }
 
 /* CONTENT | ICON */

--- a/packages/components/src/radio/src/Radio.css
+++ b/packages/components/src/radio/src/Radio.css
@@ -1,6 +1,7 @@
 .o-ui-radio {
     --o-ui-radio-background-color: var(--hop-neutral-icon-selected);
     --o-ui-radio-border-color: var(--hop-neutral-border);
+    --o-ui-radio-size: 1.5rem;
     display: inline-flex;
     align-items: flex-start;
     justify-content: flex-start;
@@ -40,9 +41,13 @@
 }
 
 /* BUTTON | SMALL */
+.o-ui-radio-sm {
+    --o-ui-radio-size: 1rem;
+}
+
 .o-ui-radio-sm .o-ui-radio-button {
-    width: 1rem;
-    height: 1rem;
+    width: var(--o-ui-radio-size);
+    height: var(--o-ui-radio-size);
 }
 
 .o-ui-radio-sm .o-ui-radio-button::before {
@@ -51,8 +56,11 @@
 
 /* CONTENT | LABEL | SMALL */
 .o-ui-radio-label {
-    margin-block-start: calc((1.5rem - (var(--hop-body-md-line-height) * var(--hop-body-md-font-size))) / 2);
     margin-left: var(--hop-space-inline-sm);
+}
+
+.o-ui-radio-counter, .o-ui-radio-label {
+    margin-top: calc((var(--o-ui-radio-size) - (var(--hop-body-md-line-height) * var(--hop-body-md-font-size))) / 2);
 }
 
 /* CONTENT | LABEL | REVERSE */
@@ -62,8 +70,9 @@
 }
 
 /* CONTENT | LABEL | SMALL */
-.o-ui-radio-sm .o-ui-radio-label {
-    margin-block-start: calc((1rem - (var(--hop-body-sm-line-height) * var(--hop-body-sm-font-size))) / 2);
+.o-ui-radio-sm .o-ui-radio-label,
+.o-ui-radio-sm .o-ui-radio-counter {
+    margin-top: calc((var(--o-ui-radio-size) - (var(--hop-body-sm-line-height) * var(--hop-body-sm-font-size))) / 2);
 }
 
 /* CONTENT | ICON */

--- a/packages/components/src/switch/src/Switch.css
+++ b/packages/components/src/switch/src/Switch.css
@@ -5,6 +5,7 @@
     --o-ui-switch-background-focus: var(--hop-neutral-surface-hover);
     --o-ui-switch-border-focus: var(--hop-neutral-border-hover);
     --o-ui-switch-dot-background-focus: var(--hop-neutral-icon-hover);
+    --o-ui-switch-height: 1.5rem;
     display: inline-flex;
     align-items: flex-start;
     justify-content: flex-start;
@@ -131,9 +132,13 @@
 
 /* SIZING */
 /* SMALL */
+.o-ui-switch-sm {
+    --o-ui-switch-height: 1rem;
+}
+
 .o-ui-switch-sm .o-ui-switch-control {
     width: 2rem;
-    height: 1rem;
+    height: var(--o-ui-switch-height);
 }
 
 .o-ui-switch-sm .o-ui-switch-control::before {
@@ -147,14 +152,15 @@
     transform: translate(calc(2rem - 0.75rem - var(--o-ui-switch-control-before-transform-translate-value)), -50%);
 }
 
-.o-ui-switch-sm .o-ui-switch-label {
-    margin-block-start: calc((1rem - (var(--hop-body-sm-line-height) * var(--hop-body-sm-font-size))) / 2);
+.o-ui-switch-sm .o-ui-switch-label,
+.o-ui-switch-sm .o-ui-switch-counter {
+    margin-top: calc((var(--o-ui-switch-height) - (var(--hop-body-sm-line-height) * var(--hop-body-sm-font-size))) / 2);
 }
 
 /* MEDIUM */
 .o-ui-switch-md .o-ui-switch-control {
     width: 3rem;
-    height: 1.5rem;
+    height: var(--o-ui-switch-height);
 }
 
 .o-ui-switch-md .o-ui-switch-control::before {
@@ -166,6 +172,7 @@
     transform: translate(calc(3rem - 1rem - var(--o-ui-switch-control-before-transform-translate-value)), -50%);
 }
 
-.o-ui-switch-md .o-ui-switch-label {
-    margin-block-start: calc((1.5rem - (var(--hop-body-md-line-height) * var(--hop-body-md-font-size))) / 2);
+.o-ui-switch-md .o-ui-switch-label,
+.o-ui-switch-md .o-ui-switch-counter {
+    margin-top: calc((var(--o-ui-switch-height) - (var(--hop-body-md-line-height) * var(--hop-body-md-font-size))) / 2);
 }

--- a/packages/components/src/switch/src/Switch.css
+++ b/packages/components/src/switch/src/Switch.css
@@ -5,8 +5,9 @@
     --o-ui-switch-background-focus: var(--hop-neutral-surface-hover);
     --o-ui-switch-border-focus: var(--hop-neutral-border-hover);
     --o-ui-switch-dot-background-focus: var(--hop-neutral-icon-hover);
-    display: inline-flex;
-    align-items: center;
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-start;
     cursor: pointer;
     max-width: 100%;
     width: max-content;
@@ -41,7 +42,6 @@
 
 /* LABEL */
 .o-ui-switch-label {
-    grid-area: label;
     margin-left: var(--hop-space-inline-sm);
 }
 
@@ -147,6 +147,10 @@
     transform: translate(calc(2rem - 0.75rem - var(--o-ui-switch-control-before-transform-translate-value)), -50%);
 }
 
+.o-ui-switch-sm .o-ui-switch-label {
+    margin-block-start: calc((1rem - (var(--hop-body-sm-line-height) * var(--hop-body-sm-font-size))) / 2);
+}
+
 /* MEDIUM */
 .o-ui-switch-md .o-ui-switch-control {
     width: 3rem;
@@ -160,4 +164,8 @@
 
 .o-ui-switch-md.o-ui-switch-checked .o-ui-switch-control::before {
     transform: translate(calc(3rem - 1rem - var(--o-ui-switch-control-before-transform-translate-value)), -50%);
+}
+
+.o-ui-switch-md .o-ui-switch-label {
+    margin-block-start: calc((1.5rem - (var(--hop-body-md-line-height) * var(--hop-body-md-font-size))) / 2);
 }

--- a/packages/components/src/switch/src/Switch.css
+++ b/packages/components/src/switch/src/Switch.css
@@ -5,7 +5,7 @@
     --o-ui-switch-background-focus: var(--hop-neutral-surface-hover);
     --o-ui-switch-border-focus: var(--hop-neutral-border-hover);
     --o-ui-switch-dot-background-focus: var(--hop-neutral-icon-hover);
-    display: flex;
+    display: inline-flex;
     align-items: flex-start;
     justify-content: flex-start;
     cursor: pointer;


### PR DESCRIPTION
Issue: https://workleap.atlassian.net/browse/DS-354

## Summary

Just did the change to let text wrap, but instead of centering everything, it should align to the top instead

## What I did

Changed to flex and added a margin-block-start to the labels. Same strategy as in Hopper.

## How to test

- Is this testable with Jest or Chromatic screenshots? yes
