### PR TITLE
Feature/ds 414 styling orbiter

### DIFF
--- a/.storybook/decorators/withDocsContainer.tsx
+++ b/.storybook/decorators/withDocsContainer.tsx
@@ -1,11 +1,16 @@
 import { ThemeProvider } from "@components/styling";
 import { DocsContainer } from "@storybook/blocks";
-
+import { MDXProvider } from "@mdx-js/react";
+import { mdxComponents } from "../mdx/components";
 
 export function ThemedDocsContainer({ children, ...props }) {
     return (
         <ThemeProvider colorScheme="light">
-            <DocsContainer {...props}>{children}</DocsContainer>;
-        </ThemeProvider>
+            <MDXProvider
+                components={mdxComponents}
+            >
+                <DocsContainer {...props}>{children}</DocsContainer>;
+            </MDXProvider>
+        </ThemeProvider >
     );
 }

--- a/.storybook/mdx/components.ts
+++ b/.storybook/mdx/components.ts
@@ -1,0 +1,14 @@
+import { H1, H2, H3, H4, H5, H6, LI, P } from "./typography";
+import { Highlight } from "./highlight";
+
+export const mdxComponents = {
+    blockquote: Highlight,
+    h1: H1,
+    h2: H2,
+    h3: H3,
+    h4: H4,
+    h5: H5,
+    h6: H6,
+    li: LI,
+    p: P
+};

--- a/.storybook/mdx/index.ts
+++ b/.storybook/mdx/index.ts
@@ -1,1 +1,0 @@
-export * from "./highlight";

--- a/.storybook/mdx/typography/Heading.tsx
+++ b/.storybook/mdx/typography/Heading.tsx
@@ -1,0 +1,8 @@
+import { mergeProps } from "../../../packages/components/src/shared";
+
+export const H1 = props => <h1 {...mergeProps(props, { className: "orbiter-doc-h1" })} />;
+export const H2 = props => <h2 {...mergeProps(props, { className: "orbiter-doc-h2" })} />;
+export const H3 = props => <h3 {...mergeProps(props, { className: "orbiter-doc-h3" })} />;
+export const H4 = props => <h4 {...mergeProps(props, { className: "orbiter-doc-h4" })} />;
+export const H5 = props => <h5 {...mergeProps(props, { className: "orbiter-doc-h5" })} />;
+export const H6 = props => <h6 {...mergeProps(props, { className: "orbiter-doc-h6" })} />;

--- a/.storybook/mdx/typography/ListItem.tsx
+++ b/.storybook/mdx/typography/ListItem.tsx
@@ -1,0 +1,3 @@
+import { mergeProps } from "../../../packages/components/src/shared";
+
+export const LI = props => <li {...mergeProps(props, { className: "orbiter-doc-li" })} />;

--- a/.storybook/mdx/typography/Paragraph.tsx
+++ b/.storybook/mdx/typography/Paragraph.tsx
@@ -1,0 +1,3 @@
+import { mergeProps } from "../../../packages/components/src/shared";
+
+export const P = props => <p {...mergeProps(props, { className: "orbiter-doc-p" })} />;

--- a/.storybook/mdx/typography/index.ts
+++ b/.storybook/mdx/typography/index.ts
@@ -1,0 +1,3 @@
+export * from "./Heading";
+export * from "./ListItem";
+export * from "./Paragraph";

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -34,7 +34,7 @@ const preview: Preview = {
         docs: {
             theme: Themes.docs,
             container: ThemedDocsContainer,
-            inlineStories: true,
+            story: { inline: true },
             canvas: {
                 sourceState: "shown"
             },

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,3 @@
-// import { viewport, withHopperProvider } from "./storybook-addon/index";
 import { viewport } from "./storybook-addon/index";
 import { withBackgroundMatchingColorScheme, withCenteredCanvas, ThemedDocsContainer, withThemeProvider } from "./decorators";
 import "./stories.css";
@@ -10,7 +9,6 @@ import type { Preview } from "@storybook/react";
 import "@components/index.css";
 import "./styles";
 import "@hopper-ui/tokens/fonts.css";
-import { Highlight } from "./mdx";
 
 if (!isChromatic) {
     // Custom font makes chromatic inconsistent and cause "false positive". View https://www.chromatic.com/docs/resource-loading#loading-custom-fonts.
@@ -39,9 +37,6 @@ const preview: Preview = {
             inlineStories: true,
             canvas: {
                 sourceState: "shown"
-            },
-            components: {
-                blockquote: Highlight
             },
             source: {
                 type: "code",

--- a/.storybook/styles/docs.css
+++ b/.storybook/styles/docs.css
@@ -134,73 +134,74 @@
 }
 
 /* ELEMENTS | TEXT */
-.sbdocs.sbdocs-h1,
-.sbdocs.sbdocs-h2,
-.sbdocs.sbdocs-h3,
-.sbdocs.sbdocs-h4,
-.sbdocs.sbdocs-h5,
-.sbdocs.sbdocs-h6,
-.sbdocs.sbdocs-p {
+h1.orbiter-doc-h1,
+h2.orbiter-doc-h2,
+h3.orbiter-doc-h3,
+h4.orbiter-doc-h4,
+h5.orbiter-doc-h5,
+h6.orbiter-doc-h6,
+p.orbiter-doc-p {
     color: var(--hop-neutral-text);
 }
 
 /* ELEMENTS | HEADER */
-.sbdocs.sbdocs-h1,
-.sbdocs.sbdocs-h2,
-.sbdocs.sbdocs-h3,
-.sbdocs.sbdocs-h4,
-.sbdocs.sbdocs-h5,
-.sbdocs.sbdocs-h6 {
+h1.orbiter-doc-h1,
+h2.orbiter-doc-h2,
+h3.orbiter-doc-h3,
+h4.orbiter-doc-h4,
+h5.orbiter-doc-h5,
+h6.orbiter-doc-h6 {
     font-weight: 550;
     /* fixing the default position relative on all titles in shared.tsx */
     position: initial;
 }
 
-.sbdocs.sbdocs-h1 {
+h1.orbiter-doc-h1 {
     font-size: var(--hop-heading-3xl-font-size);
     line-height: var(--hop-heading-3xl-line-height);
 }
 
-.sbdocs.sbdocs-h1,
+h1.orbiter-doc-h1,
 .sbdocs .sbdocs-title {
     font-weight: 550;
 }
 
-.sbdocs.sbdocs-h2 {
+h2.orbiter-doc-h2 {
     border-bottom: 1px solid var(--hop-neutral-border-weakest);
 }
 
-.sbdocs.sbdocs-h2,
-.sbdocs.sbdocs-h2:first-of-type {
+h2.orbiter-doc-h2,
+h2.orbiter-doc-h2:first-of-type {
     margin: 1.5rem 0;
     font-size: var(--hop-heading-xl-font-size);
 }
 
-.sbdocs.sbdocs.sbdocs-h3 {
+h3.orbiter-doc-h3,
+h3.orbiter-doc-h3:first-of-type {
     margin: var(--hop-space-stack-xl) 0 var(--hop-space-stack-md);
     font-size: var(--hop-heading-md-font-size);
     line-height: var(--hop-heading-md-line-height);
 }
 
-.sbdocs.sbdocs.sbdocs-h4 {
+h4.orbiter-doc-h4 {
     font-size: var(--hop-heading-sm-font-size);
     line-height: var(--hop-heading-sm-line-height);
     margin: var(--hop-space-stack-lg) 0 var(--hop-space-stack-sm);
 }
 
-.sbdocs.sbdocs-h2 + .sbdocs.sbdocs-p,
-.sbdocs.sbdocs-h3 + .sbdocs.sbdocs-p,
-.sbdocs.sbdocs-h4 + .sbdocs.sbdocs-p {
+h2.orbiter-doc-h2 + p.orbiter-doc-p,
+h3.orbiter-doc-h3 + p.orbiter-doc-p,
+h4.orbiter-doc-h4 + p.orbiter-doc-p {
     margin: 0 0 1rem 0;
 }
 
-.sbdocs.sbdocs-p {
+p.orbiter-doc-p {
     max-width: 75ch;
 }
 
 /* ELEMENTS | CODE | IN PARAGRAPH */
-.sbdocs .sbdocs-p code,
-.sbdocs .sbdocs-li code {
+.sbdocs p.orbiter-doc-p code,
+.sbdocs li.orbiter-doc-li code {
     padding: 0 !important;
     border: none !important;
     border-radius: 0 !important;
@@ -215,6 +216,10 @@
     text-decoration: underline;
 }
 
+.sbdocs.sbdocs-a code {
+    text-decoration: underline;
+}
+
 .sbdocs.sbdocs-a:hover,
 .sbdocs.sbdocs-a:focus {
     text-decoration: underline;
@@ -222,7 +227,7 @@
 }
 
 /* ELEMENTS | LINK | IN PARAGRAGH */
-.sbdocs.sbdocs-p .sbdocs-a {
+p.orbiter-doc-p .sbdocs-a {
     font-size: inherit;
 }
 
@@ -237,72 +242,11 @@
 }
 
 /* ELEMENTS | TYPOGRAPHY */
-.sbdocs.sbdocs-p,
+p.orbiter-doc-p,
 .sbdocs.sbdocs-span {
     font-size: var(--hop-body-md-font-size);
     line-height: var(--hop-body-md-line-height);
     max-width: 90ch;
-}
-
-/* ELEMENTS | TABLE */
-.sbdocs.sbdocs-table tr {
-    border-top: 1px solid var(--hop-neutral-border-weakest);
-}
-
-.sbdocs.sbdocs-table .thead tr th {
-    background-color: var(--hop-neutral-surface-weak);
-    color: inherit;
-}
-
-.sbdocs.sbdocs-table thead tr {
-    border-top: 1px solid var(--hop-neutral-border-weakest);
-    border-left: 1px solid var(--hop-neutral-border-weakest);
-    border-right: 1px solid var(--hop-neutral-border-weakest);
-    color: var(--hop-neutral-text);
-}
-
-.sbdocs.sbdocs-table tr th {
-    font-weight: 600;
-    font-size: var(--hop-body-md-font-size);
-}
-
-.sbdocs.sbdocs-table td {
-    font-size: var(--hop-body-sm-medium-font-size);
-}
-
-.sbdocs.sbdocs-table tr td,
-.sbdocs.sbdocs-table tr th {
-    border-top: 1px solid var(--hop-neutral-border-weakest);
-    border-bottom: 1px solid var(--hop-neutral-border-weakest);
-    border-left: 0;
-    border-right: 0;
-    color: var(--hop-neutral-text);
-    background-color: var(--hop-neutral-surface);
-}
-
-.sbdocs.sbdocs-table tbody {
-    border: 1px solid var(--hop-neutral-border-weakest);
-}
-
-.sbdocs.sbdocs-table a {
-    font-size: var(--hop-body-sm-medium-font-size) !important;
-}
-
-.sbdocs.sbdocs-table .code a {
-    font-family: Consolas, monaco, monospace !important;
-}
-
-.sbdocs.sbdocs-table .example {
-    color: var(--hop-neutral-text);
-}
-
-.sbdocs.sbdocs-table b,
-.sbdocs.sbdocs-table strong {
-    font-weight: 400;
-}
-
-.sbdocs.sbdocs-table .sbdocs.sbdocs-img {
-    max-width: none;
 }
 
 /* ELEMENTS | SUMMARY */
@@ -342,7 +286,7 @@
 }
 
 /* ELEMENTS | LIST */
-.sbdocs.sbdocs-li {
+li.orbiter-doc-li {
     font-size: var(--hop-body-md-font-size) !important;
 }
 
@@ -352,11 +296,11 @@
 }
 
 /* ELEMENTS | LINK ICON */
-.sbdocs.sbdocs-h1 a {
+h1.orbiter-doc-h1 a {
     margin-left: -28px;
 }
 
-.sbdocs.sbdocs-h1 a svg {
+h1.orbiter-doc-h1 a svg {
     width: 1.5rem;
     height: 1.5rem;
 }

--- a/.storybook/styles/docs.css
+++ b/.storybook/styles/docs.css
@@ -114,93 +114,93 @@
     margin-bottom: 35px !important;
 }
 
-.preview,
-pre {
+.sbdocs.sbdocs-preview,
+.sbdocs.sbdocs-pre {
     border: none;
     border-radius: var(--hop-shape-rounded-md) !important;
     box-shadow: var(--hop-elevation-lifted);
 }
 
-.preview {
+.sbdocs.sbdocs-preview {
     overflow: hidden;
 }
 
-.preview > div > div {
+.sbdocs.sbdocs-preview > div > div {
     overflow: visible;
 }
 
-.preview div[scale] {
+.sbdocs.sbdocs-preview div[scale] {
     transform: none !important;
 }
 
 /* ELEMENTS | TEXT */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p {
+.sbdocs.sbdocs-h1,
+.sbdocs.sbdocs-h2,
+.sbdocs.sbdocs-h3,
+.sbdocs.sbdocs-h4,
+.sbdocs.sbdocs-h5,
+.sbdocs.sbdocs-h6,
+.sbdocs.sbdocs-p {
     color: var(--hop-neutral-text);
 }
 
 /* ELEMENTS | HEADER */
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
+.sbdocs.sbdocs-h1,
+.sbdocs.sbdocs-h2,
+.sbdocs.sbdocs-h3,
+.sbdocs.sbdocs-h4,
+.sbdocs.sbdocs-h5,
+.sbdocs.sbdocs-h6 {
     font-weight: 550;
     /* fixing the default position relative on all titles in shared.tsx */
     position: initial;
 }
 
-h1 {
+.sbdocs.sbdocs-h1 {
     font-size: var(--hop-heading-3xl-font-size);
     line-height: var(--hop-heading-3xl-line-height);
 }
 
-h1,
+.sbdocs.sbdocs-h1,
 .sbdocs .sbdocs-title {
     font-weight: 550;
 }
 
-h2 {
+.sbdocs.sbdocs-h2 {
     border-bottom: 1px solid var(--hop-neutral-border-weakest);
 }
 
-h2,
-h2:first-of-type {
-    margin: 1.5rem 0 !important;
+.sbdocs.sbdocs-h2,
+.sbdocs.sbdocs-h2:first-of-type {
+    margin: 1.5rem 0;
     font-size: var(--hop-heading-xl-font-size);
 }
 
-h3 {
+.sbdocs.sbdocs.sbdocs-h3 {
     margin: var(--hop-space-stack-xl) 0 var(--hop-space-stack-md);
     font-size: var(--hop-heading-md-font-size);
     line-height: var(--hop-heading-md-line-height);
 }
 
-h4 {
+.sbdocs.sbdocs.sbdocs-h4 {
     font-size: var(--hop-heading-sm-font-size);
     line-height: var(--hop-heading-sm-line-height);
     margin: var(--hop-space-stack-lg) 0 var(--hop-space-stack-sm);
 }
 
-h2 + p,
-h3 + p,
-h4 + p {
+.sbdocs.sbdocs-h2 + .sbdocs.sbdocs-p,
+.sbdocs.sbdocs-h3 + .sbdocs.sbdocs-p,
+.sbdocs.sbdocs-h4 + .sbdocs.sbdocs-p {
     margin: 0 0 1rem 0;
 }
 
-p {
+.sbdocs.sbdocs-p {
     max-width: 75ch;
 }
 
 /* ELEMENTS | CODE | IN PARAGRAPH */
-p code,
-li code {
+.sbdocs .sbdocs-p code,
+.sbdocs .sbdocs-li code {
     padding: 0 !important;
     border: none !important;
     border-radius: 0 !important;
@@ -209,69 +209,69 @@ li code {
 }
 
 /* ELEMENTS | LINK */
-a {
+.sbdocs.sbdocs-a {
     font-size: var(--hop-body-md-font-size);
     color: var(--hop-primary-text) !important;
     text-decoration: underline;
 }
 
-a:hover,
-a:focus {
+.sbdocs.sbdocs-a:hover,
+.sbdocs.sbdocs-a:focus {
     text-decoration: underline;
     outline: transparent;
 }
 
 /* ELEMENTS | LINK | IN PARAGRAGH */
-p a {
+.sbdocs.sbdocs-p .sbdocs-a {
     font-size: inherit;
 }
 
-a:focus {
+.sbdocs.sbdocs-a:focus {
     border-radius: var(--hop-shape-rounded-md);
     background-color: rgba(0, 0, 0, 0.04);
     box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.04);
 }
 
-a code {
+.sbdocs .sbdocs-a code {
     color: var(--hop-primary-text);
 }
 
 /* ELEMENTS | TYPOGRAPHY */
-p,
-span {
+.sbdocs.sbdocs-p,
+.sbdocs.sbdocs-span {
     font-size: var(--hop-body-md-font-size);
     line-height: var(--hop-body-md-line-height);
     max-width: 90ch;
 }
 
 /* ELEMENTS | TABLE */
-table tr {
+.sbdocs.sbdocs-table tr {
     border-top: 1px solid var(--hop-neutral-border-weakest);
 }
 
-table thead tr th {
+.sbdocs.sbdocs-table .thead tr th {
     background-color: var(--hop-neutral-surface-weak);
     color: inherit;
 }
 
-table thead tr {
+.sbdocs.sbdocs-table thead tr {
     border-top: 1px solid var(--hop-neutral-border-weakest);
     border-left: 1px solid var(--hop-neutral-border-weakest);
     border-right: 1px solid var(--hop-neutral-border-weakest);
     color: var(--hop-neutral-text);
 }
 
-table tr th {
+.sbdocs.sbdocs-table tr th {
     font-weight: 600;
     font-size: var(--hop-body-md-font-size);
 }
 
-table td {
+.sbdocs.sbdocs-table td {
     font-size: var(--hop-body-sm-medium-font-size);
 }
 
-table tr td,
-table tr th {
+.sbdocs.sbdocs-table tr td,
+.sbdocs.sbdocs-table tr th {
     border-top: 1px solid var(--hop-neutral-border-weakest);
     border-bottom: 1px solid var(--hop-neutral-border-weakest);
     border-left: 0;
@@ -280,28 +280,28 @@ table tr th {
     background-color: var(--hop-neutral-surface);
 }
 
-table tbody {
+.sbdocs.sbdocs-table tbody {
     border: 1px solid var(--hop-neutral-border-weakest);
 }
 
-table a {
+.sbdocs.sbdocs-table a {
     font-size: var(--hop-body-sm-medium-font-size) !important;
 }
 
-table .code a {
+.sbdocs.sbdocs-table .code a {
     font-family: Consolas, monaco, monospace !important;
 }
 
-table .example {
+.sbdocs.sbdocs-table .example {
     color: var(--hop-neutral-text);
 }
 
-table b,
-table strong {
+.sbdocs.sbdocs-table b,
+.sbdocs.sbdocs-table strong {
     font-weight: 400;
 }
 
-table img {
+.sbdocs.sbdocs-table .sbdocs.sbdocs-img {
     max-width: none;
 }
 
@@ -342,7 +342,7 @@ table img {
 }
 
 /* ELEMENTS | LIST */
-li {
+.sbdocs.sbdocs-li {
     font-size: var(--hop-body-md-font-size) !important;
 }
 
@@ -352,11 +352,11 @@ li {
 }
 
 /* ELEMENTS | LINK ICON */
-h1 a {
+.sbdocs.sbdocs-h1 a {
     margin-left: -28px;
 }
 
-h1 a svg {
+.sbdocs.sbdocs-h1 a svg {
     width: 1.5rem;
     height: 1.5rem;
 }

--- a/docs/features/ResponsiveStyles.mdx
+++ b/docs/features/ResponsiveStyles.mdx
@@ -7,7 +7,7 @@ import * as ResponsiveStylesStories from "./ResponsiveStyles.stories";
 
 # Responsive styles
 
-Orbiter [style props](?path=/docs/style-props--page) accepts a specialized syntax to support responsive breakpoints.
+Orbiter [style props](?path=/docs/style-props--docs) accepts a specialized syntax to support responsive breakpoints.
 
 ## Usage
 
@@ -33,7 +33,7 @@ const fluidValue = useResponsiveValue({ base: true, lg: false });
 
 ## Breakpoints
 
-The following responsive breakpoints are supported by Orbiter [style props](?path=/docs/style-props--page) and acts as their [CSS media query](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries) counterparts:
+The following responsive breakpoints are supported by Orbiter [style props](?path=/docs/style-props--docs) and acts as their [CSS media query](https://developer.mozilla.org/en-US/docs/Web/CSS/Media_Queries/Using_media_queries) counterparts:
 
 <Table
     columns={[

--- a/docs/features/color-schemes/ColorSchemes.mdx
+++ b/docs/features/color-schemes/ColorSchemes.mdx
@@ -5,7 +5,7 @@ import * as ColorSchemesStories from  "./ColorSchemes.stories";
 
 # Color schemes
 
-Orbiter supports by default a *light* and a *dark* color scheme for all components and [tokens](?path=/story/tokens--page) where applicable.
+Orbiter supports by default a *light* and a *dark* color scheme for all components and [tokens](?path=/story/tokens--docs) where applicable.
 
 ## Apply a color scheme
 
@@ -31,7 +31,7 @@ The `ColorSchemeContext` of the closest [theme provider](?path=/story/theme-prov
 
 ## useColorSchemeValue
 
-Some features requires the usage of custom colors. Those colors aren't like Orbiter [tokens](?path=/story/tokens--page) and will not support color schemes out of the box.
+Some features requires the usage of custom colors. Those colors aren't like Orbiter [tokens](?path=/story/tokens--docs) and will not support color schemes out of the box.
 
 To help with that, Orbiter offer the `useColorSchemeValue` hook which will return the value matching the current color scheme of the closest [theme provider](?path=/story/theme-provider--default-story).
 

--- a/docs/features/style-props/PropsReferenceTable.tsx
+++ b/docs/features/style-props/PropsReferenceTable.tsx
@@ -1,10 +1,10 @@
 import { Table, TableProps, Link } from "@stories/components";
 
 const ScaleLinks = {
-    "box-shadow-scale": <Link href="?path=/docs/tokens--page#box-shadows" target="_blank">shadows</Link>,
-    "color-scale": <Link href="?path=/docs/tokens--page#background-colors" target="_blank">colors</Link>,
-    "sizing-scale": <Link href="?path=/docs/tokens--page#sizings" target="_blank">dimensions</Link>,
-    "spacing-scale": <Link href="?path=/docs/tokens--page#spacings" target="_blank">dimensions</Link>
+    "box-shadow-scale": <Link href="?path=/docs/tokens--docs#box-shadows" target="_blank">shadows</Link>,
+    "color-scale": <Link href="?path=/docs/tokens--docs#background-colors" target="_blank">colors</Link>,
+    "sizing-scale": <Link href="?path=/docs/tokens--docs#sizings" target="_blank">dimensions</Link>,
+    "spacing-scale": <Link href="?path=/docs/tokens--docs#spacings" target="_blank">dimensions</Link>
 };
 
 function toScaleLink(scale: keyof typeof ScaleLinks) {

--- a/docs/features/style-props/StyleProps.mdx
+++ b/docs/features/style-props/StyleProps.mdx
@@ -43,11 +43,11 @@ Props like `border` and `paddingX` are also provided to help you save keystrokes
 
 ## TypeScript Intellisense
 
-Inspired by [Styled System](https://styled-system.com/), Orbiter's style props are flexible and easy to discover with [TypeScript](https://www.typescriptlang.org/) intellisense. Style values intellisense will offer suggestions matching the values of the provided [theme](?path=/docs/theming--page) as well as native CSS values of the property. You won't have to guess or open external documentation to pick a value.
+Inspired by [Styled System](https://styled-system.com/), Orbiter's style props are flexible and easy to discover with [TypeScript](https://www.typescriptlang.org/) intellisense. Style values intellisense will offer suggestions matching the values of the provided [theme](?path=/docs/theming--docs) as well as native CSS values of the property. You won't have to guess or open external documentation to pick a value.
 
 ## Scale values
 
-To help achieve a consistent user interface, Orbiter style props are based on scales and values defined in a customizable [theme](?path=/docs/theming--page).
+To help achieve a consistent user interface, Orbiter style props are based on scales and values defined in a customizable [theme](?path=/docs/theming--docs).
 
 <Canvas of={StylePropsStories.ScaleValues} />
 
@@ -84,7 +84,7 @@ You might wonder how will you use Orbiter style props on your HTML elements?
 
 Orbiter provides a set of HTML elements components already configured with Orbiter styled system. You should chose these components over native HTML elements.
 
-[`<A>`](?path=/docs/html-anchor--example), [`<Address>`](?path=/docs/html-address--example), [`<Article>`](?path=/docs/html-article--page), [`<Aside>`](?path=/docs/html-aside--page), [`<Button>`](?path=/docs/html-button--example), [`<Div>`](?path=/docs/html-div--example), [`<Footer>`](?path=/docs/html-footer--page), [`<Header>`](?path=/docs/html-header--page), [`<Img>`](?path=/docs/html-img--example), [`<Input>`](?path=/docs/html-input--example), [`<List>`](?path=/docs/html-list--example), [`<Main>`](?path=/docs/html-main--page), [`<Nav>`](?path=/docs/html-nav--page), [`<Section>`](?path=/docs/html-section--page), [`<Span>`](?path=/docs/html-span--example), [`<Table>`](?path=/docs/html-table--example)
+[`<A>`](?path=/docs/html-anchor--example), [`<Address>`](?path=/docs/html-address--example), [`<Article>`](?path=/docs/html-article--docs), [`<Aside>`](?path=/docs/html-aside--docs), [`<Button>`](?path=/docs/html-button--example), [`<Div>`](?path=/docs/html-div--example), [`<Footer>`](?path=/docs/html-footer--docs), [`<Header>`](?path=/docs/html-header--docs), [`<Img>`](?path=/docs/html-img--example), [`<Input>`](?path=/docs/html-input--example), [`<List>`](?path=/docs/html-list--example), [`<Main>`](?path=/docs/html-main--docs), [`<Nav>`](?path=/docs/html-nav--docs), [`<Section>`](?path=/docs/html-section--docs), [`<Span>`](?path=/docs/html-span--example), [`<Table>`](?path=/docs/html-table--example)
 
 For text elements, prefer a [`<Text>`](?path=/docs/text--size) or [`<Paragraph>`](?path=/docs/paragraph--size) component rather than `<Span>` or a `<Div>`.
 

--- a/docs/features/tokens/Tokens.mdx
+++ b/docs/features/tokens/Tokens.mdx
@@ -28,7 +28,7 @@ Tokens are Orbiter's reusable values to provide a common language between develo
 
 ## Usage
 
-Tokens can be used as [style props](/docs/style-props--page) values:
+Tokens can be used as [style props](/docs/style-props--docs) values:
 
 <Source dark language="tsx" of={TokensStories.Usage} />
 
@@ -44,7 +44,7 @@ Or `CSS` variables:
 
 Those tokens are named for their use case, rather than their value. For example `danger` is named to indicate the appropriate background color for an error message background, as opposed to `amanita-400` which is less specific and could be used in a number of ways depending on the context.
 
-This makes their intended use clear and intentional, and allows us to develop a scalable and consistent visual language while also being the building block of Orbit's [theming](/docs/theming--page).
+This makes their intended use clear and intentional, and allows us to develop a scalable and consistent visual language while also being the building block of Orbit's [theming](/docs/theming--docs).
 
 ### Deprecation notice
 

--- a/packages/components/src/accordion/docs/Accordion.mdx
+++ b/packages/components/src/accordion/docs/Accordion.mdx
@@ -38,7 +38,7 @@ A default accordion.
 
 ### Icon
 
-An accordion item can contain [icons](?path=/docs/icon-gallery--page).
+An accordion item can contain [icons](?path=/docs/icon-gallery--docs).
 
 <Canvas of={AccordionStories.Icon} />
 

--- a/packages/components/src/autocomplete/docs/Autocomplete.mdx
+++ b/packages/components/src/autocomplete/docs/Autocomplete.mdx
@@ -32,13 +32,13 @@ An autocomplete items can be group by sections.
 
 ### Item icon
 
-An autocomplete item can have [icons](?path=/docs/icon-gallery--page).
+An autocomplete item can have [icons](?path=/docs/icon-gallery--docs).
 
 <Canvas of={AutocompleteStories.ItemIcon} />
 
 ### Item end icon
 
-An autocomplete item can have *non standard* end [icons](?path=/docs/icon-gallery--page) can be provided to handle special cases like displaying a list of icons. However, think twice before adding *end* icons, *start* icons should be your go to.
+An autocomplete item can have *non standard* end [icons](?path=/docs/icon-gallery--docs) can be provided to handle special cases like displaying a list of icons. However, think twice before adding *end* icons, *start* icons should be your go to.
 
 <Canvas of={AutocompleteStories.ItemEndIcon} />
 
@@ -48,7 +48,7 @@ An autocomplete item can have a description.
 
 <Canvas of={AutocompleteStories.ItemDescription} />
 
-A description can be paired with an [icon](?path=/docs/icon-gallery--page).
+A description can be paired with an [icon](?path=/docs/icon-gallery--docs).
 
 <Canvas of={AutocompleteStories.ItemDescriptionIcon} />
 

--- a/packages/components/src/badge/docs/Badge.mdx
+++ b/packages/components/src/badge/docs/Badge.mdx
@@ -31,7 +31,7 @@ A badge can be rendered as a dot. A single digit is supported.
 
 ### Icon
 
-A badge can be an [icon](?path=/docs/icon-gallery--page).
+A badge can be an [icon](?path=/docs/icon-gallery--docs).
 
 <Canvas of={BadgeStories.Icon} />
 

--- a/packages/components/src/button/docs/Button.mdx
+++ b/packages/components/src/button/docs/Button.mdx
@@ -53,13 +53,13 @@ A default button.
 
 ### Icon
 
-A button can contain [icons](?path=/docs/icon-gallery--page).
+A button can contain [icons](?path=/docs/icon-gallery--docs).
 
 <Canvas of={ButtonStories.Icon} />
 
 ### End icon
 
-*Non standard* end [icons](?path=/docs/icon-gallery--page) can be provided to handle special cases. However, think twice before adding *end* icons, *start* icons should be your go to.
+*Non standard* end [icons](?path=/docs/icon-gallery--docs) can be provided to handle special cases. However, think twice before adding *end* icons, *start* icons should be your go to.
 
 <Canvas of={ButtonStories.EndIcon} />
 

--- a/packages/components/src/checkbox/docs/Checkbox.mdx
+++ b/packages/components/src/checkbox/docs/Checkbox.mdx
@@ -50,7 +50,7 @@ A checkbox can be disabled.
 
 ### Icon
 
-A checkbox can have [icons](?path=/docs/icon-gallery--page) after his label.
+A checkbox can have [icons](?path=/docs/icon-gallery--docs) after his label.
 
 <Canvas of={CheckboxStories.Icon} />
 

--- a/packages/components/src/html/docs/address.mdx
+++ b/packages/components/src/html/docs/address.mdx
@@ -15,6 +15,6 @@ import * as AddressStories from "./address.stories.tsx";
 
 ## Usage
 
-An address component accepts all the [address HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address) and [Orbiter styled component props](?path=/docs/styling--page).
+An address component accepts all the [address HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/address) and [Orbiter styled component props](?path=/docs/styling--docs).
 
 <Canvas of={AddressStories.Example} />

--- a/packages/components/src/html/docs/anchor.mdx
+++ b/packages/components/src/html/docs/anchor.mdx
@@ -15,6 +15,6 @@ import * as AStories from "./anchor.stories.tsx";
 
 ## Usage
 
-An anchor component accepts all the [anchor HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) and [Orbiter styled component props](?path=/docs/styling--page).
+An anchor component accepts all the [anchor HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a) and [Orbiter styled component props](?path=/docs/styling--docs).
 
 <Canvas of={AStories.Example} />

--- a/packages/components/src/html/docs/article.mdx
+++ b/packages/components/src/html/docs/article.mdx
@@ -15,6 +15,6 @@ import * as ArticleStories from "./article.stories.tsx";
 
 ## Usage
 
-An article component accepts all the [article HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article) and [Orbiter styled component props](?path=/docs/styling--page).
+An article component accepts all the [article HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/article) and [Orbiter styled component props](?path=/docs/styling--docs).
 
 <Canvas of={ArticleStories.Example} />

--- a/packages/components/src/html/docs/aside.mdx
+++ b/packages/components/src/html/docs/aside.mdx
@@ -15,6 +15,6 @@ import * as AsideStories from "./aside.stories.tsx";
 
 ## Usage
 
-An aside component accepts all the [aside HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside) and [Orbiter styled component props](?path=/docs/styling--page).
+An aside component accepts all the [aside HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/aside) and [Orbiter styled component props](?path=/docs/styling--docs).
 
 <Canvas of={AsideStories.Example} />

--- a/packages/components/src/html/docs/button.mdx
+++ b/packages/components/src/html/docs/button.mdx
@@ -15,6 +15,6 @@ import * as ButtonStories from "./button.stories.tsx";
 
 ## Usage
 
-A button component accepts all the [button HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button) and [Orbiter styled component props](?path=/docs/styling--page).
+A button component accepts all the [button HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button) and [Orbiter styled component props](?path=/docs/styling--docs).
 
 <Canvas of={ButtonStories.Example} />

--- a/packages/components/src/html/docs/div.mdx
+++ b/packages/components/src/html/docs/div.mdx
@@ -15,6 +15,6 @@ import * as DivStories from "./div.stories.tsx";
 
 ## Usage
 
-A div component accepts all the [div HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div) and [Orbiter styled component props](?path=/docs/styling--page).
+A div component accepts all the [div HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/div) and [Orbiter styled component props](?path=/docs/styling--docs).
 
 <Canvas of={DivStories.Example} />

--- a/packages/components/src/html/docs/footer.mdx
+++ b/packages/components/src/html/docs/footer.mdx
@@ -15,6 +15,6 @@ import * as FooterStories from "./footer.stories.tsx";
 
 ## Usage
 
-A footer component accepts all the [footer HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer) and [Orbiter styled component props](?path=/docs/styling--page).
+A footer component accepts all the [footer HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer) and [Orbiter styled component props](?path=/docs/styling--docs).
 
 <Canvas of={FooterStories.Example} />

--- a/packages/components/src/html/docs/header.mdx
+++ b/packages/components/src/html/docs/header.mdx
@@ -15,6 +15,6 @@ import * as HeaderStories from "./header.stories.tsx";
 
 ## Usage
 
-An header component accepts all the [header HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header) and [Orbiter styled component props](?path=/docs/styling--page).
+An header component accepts all the [header HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header) and [Orbiter styled component props](?path=/docs/styling--docs).
 
 <Canvas of={HeaderStories.Example} />

--- a/packages/components/src/html/docs/img.mdx
+++ b/packages/components/src/html/docs/img.mdx
@@ -15,6 +15,6 @@ import * as ImgStories from "./img.stories.tsx";
 
 ## Usage
 
-An img component accepts all the [HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img) and [Orbiter styled component props](?path=/docs/styling--page).
+An img component accepts all the [HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img) and [Orbiter styled component props](?path=/docs/styling--docs).
 
 <Canvas of={ImgStories.Example} />

--- a/packages/components/src/html/docs/input.mdx
+++ b/packages/components/src/html/docs/input.mdx
@@ -15,6 +15,6 @@ import * as InputStories from "./input.stories.tsx";
 
 ## Usage
 
-An input component accepts all the [input HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) and [Orbiter styled component props](?path=/docs/styling--page).
+An input component accepts all the [input HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input) and [Orbiter styled component props](?path=/docs/styling--docs).
 
 <Canvas of={InputStories.Example} />

--- a/packages/components/src/html/docs/list.mdx
+++ b/packages/components/src/html/docs/list.mdx
@@ -15,6 +15,6 @@ import * as ListStories from "./list.stories.tsx";
 
 ## Usage
 
-Accepts all the HTML attributes of [ul](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul), [ol](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol) and [li](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li) elements with the addition of [Orbiter styled component props](?path=/docs/styling--page).
+Accepts all the HTML attributes of [ul](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ul), [ol](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/ol) and [li](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li) elements with the addition of [Orbiter styled component props](?path=/docs/styling--docs).
 
 <Canvas of={ListStories.Example} />

--- a/packages/components/src/html/docs/main.mdx
+++ b/packages/components/src/html/docs/main.mdx
@@ -15,6 +15,6 @@ import * as MainStories from "./main.stories.tsx";
 
 ## Usage
 
-A main component accepts all the [main HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main) and [Orbiter styled component props](?path=/docs/styling--page).
+A main component accepts all the [main HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/main) and [Orbiter styled component props](?path=/docs/styling--docs).
 
 <Canvas of={MainStories.Example} />

--- a/packages/components/src/html/docs/nav.mdx
+++ b/packages/components/src/html/docs/nav.mdx
@@ -15,6 +15,6 @@ import * as NavStories from "./nav.stories.tsx";
 
 ## Usage
 
-A nav component accepts all the [nav HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav) and [Orbiter styled component props](?path=/docs/styling--page).
+A nav component accepts all the [nav HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/nav) and [Orbiter styled component props](?path=/docs/styling--docs).
 
 <Canvas of={NavStories.Example} />

--- a/packages/components/src/html/docs/section.mdx
+++ b/packages/components/src/html/docs/section.mdx
@@ -15,6 +15,6 @@ import * as SectionStories from "./section.stories.tsx";
 
 ## Usage
 
-A section component accepts all the [section HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section) and [Orbiter styled component props](?path=/docs/styling--page).
+A section component accepts all the [section HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/section) and [Orbiter styled component props](?path=/docs/styling--docs).
 
 <Canvas of={SectionStories.Example} />

--- a/packages/components/src/html/docs/span.mdx
+++ b/packages/components/src/html/docs/span.mdx
@@ -15,6 +15,6 @@ import * as SpanStories from "./span.stories.tsx";
 
 ## Usage
 
-A span component accepts all the [HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span) and [Orbiter styled component props](?path=/docs/styling--page).
+A span component accepts all the [HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/span) and [Orbiter styled component props](?path=/docs/styling--docs).
 
 <Canvas of={SpanStories.Example} />

--- a/packages/components/src/html/docs/table.mdx
+++ b/packages/components/src/html/docs/table.mdx
@@ -15,6 +15,6 @@ import * as TableStories from "./table.stories.tsx";
 
 ## Usage
 
-A table component accepts all the [table HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table) and [Orbiter styled component props](?path=/docs/styling--page).
+A table component accepts all the [table HTML element attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table) and [Orbiter styled component props](?path=/docs/styling--docs).
 
 <Canvas of={TableStories.Example} />

--- a/packages/components/src/html/src/html.tsx
+++ b/packages/components/src/html/src/html.tsx
@@ -6,88 +6,88 @@ import { isNil } from "../../shared";
 // Sectioning & Content sectioning
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML address element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML address element.
  *
  * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-address--example)
 */
 export const Address = htmlElement("html-address", "address");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML article element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML article element.
  *
- * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-article--page)
+ * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-article--docs)
 */
 export const Article = htmlElement("html-article", "article");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML aside element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML aside element.
  *
- * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-aside--page)
+ * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-aside--docs)
 */
 export const Aside = htmlElement("html-aside", "aside");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML footer element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML footer element.
  *
- * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-footer--page)
+ * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-footer--docs)
 */
 export const HtmlFooter = htmlElement("html-footer", "footer");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML h1 element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML h1 element.
 */
 export const HtmlH1 = htmlElement("html-h1", "h1");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML h2 element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML h2 element.
 */
 export const HtmlH2 = htmlElement("html-h2", "h2");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML h3 element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML h3 element.
 */
 export const HtmlH3 = htmlElement("html-h3", "h3");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML h4 element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML h4 element.
 */
 export const HtmlH4 = htmlElement("html-h4", "h4");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML h5 element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML h5 element.
 */
 export const HtmlH5 = htmlElement("html-h5", "h5");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML h6 element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML h6 element.
 */
 export const HtmlH6 = htmlElement("html-h6", "h6");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML header element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML header element.
  *
- * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-header--page)
+ * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-header--docs)
 */
 export const HtmlHeader = htmlElement("html-header", "header");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML main element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML main element.
  *
- * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-main--page)
+ * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-main--docs)
 */
 export const Main = htmlElement("html-main", "main");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML nav element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML nav element.
  *
- * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-nav--page)
+ * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-nav--docs)
 */
 export const Nav = htmlElement("html-nav", "nav");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML section element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML section element.
  *
- * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-section--page)
+ * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-section--docs)
 */
 export const HtmlSection = htmlElement("html-section", "section");
 
@@ -109,29 +109,29 @@ export type HtmlSectionProps = ComponentProps<typeof HtmlSection>;
 // Text content
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML div element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML div element.
  *
  * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-div--example)
 */
 export const Div = htmlElement("html-div", "div");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML p element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML p element.
 */
 export const HtmlParagraph = htmlElement("html-p", "p");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML ol element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML ol element.
 */
 export const OL = htmlElement("html-ol", "ol");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML ul element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML ul element.
 */
 export const UL = htmlElement("html-ul", "ul");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML li element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML li element.
 */
 export const LI = htmlElement("html-li", "li");
 
@@ -144,14 +144,14 @@ export type LIProps = ComponentProps<typeof LI>;
 // Inline text semantics
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML anchor element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML anchor element.
  *
  * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-anchor--example)
 */
 export const A = htmlElement("html-a", "a");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML span element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML span element.
  *
  * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-span--example)
 */
@@ -163,7 +163,7 @@ export type SpanProps = ComponentProps<typeof Span>;
 // Image and multimedia
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML img element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML img element.
  *
  * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-img--example)
 */
@@ -174,49 +174,49 @@ export type ImgProps = ComponentProps<typeof Img>;
 // Table content
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML table element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML table element.
  *
  * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-span--example)
 */
 export const Table = htmlElement("html-table", "table");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML thead element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML thead element.
  *
  * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-table--example)
 */
 export const THead = htmlElement("html-thead", "thead");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML tbody element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML tbody element.
  *
  * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-table--example)
 */
 export const TBody = htmlElement("html-tbody", "tbody");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML tfoot element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML tfoot element.
  *
  * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-table--example)
 */
 export const TFoot = htmlElement("html-tfoot", "tfoot");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML th element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML th element.
  *
  * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-table--example)
 */
 export const TH = htmlElement("html-th", "th");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML tr element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML tr element.
  *
  * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-table--example)
 */
 export const TR = htmlElement("html-tr", "tr");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML td element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML td element.
  *
  * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-table--example)
 */
@@ -232,31 +232,31 @@ export type TDProps = ComponentProps<typeof TD>;
 
 // Forms
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML button element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML button element.
  *
  * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-button--example)
 */
 export const HtmlButton = htmlElement("html-button", "button");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML form element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML form element.
 */
 export const HtmlForm = htmlElement("html-form", "form");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML input element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML input element.
  *
  * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/html-input--example)
 */
 export const HtmlInput = htmlElement("html-input", "input");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML label element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML label element.
 */
 export const HtmlLabel = htmlElement("html-label", "label");
 
 /**
- * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--page) component for HTML textarea element.
+ * A specialized [box](https://wl-orbiter-website.netlify.app/?path=/docs/box--docs) component for HTML textarea element.
 */
 export const HtmlTextArea = htmlElement("html-textarea", "textarea");
 

--- a/packages/components/src/listbox/docs/Listbox.mdx
+++ b/packages/components/src/listbox/docs/Listbox.mdx
@@ -44,13 +44,13 @@ A listbox items can be group by sections.
 
 ### Item icon
 
-A listbox item can have [icons](?path=/docs/icon-gallery--page).
+A listbox item can have [icons](?path=/docs/icon-gallery--docs).
 
 <Canvas of={ListboxStories.ItemIcon} />
 
 ### Item end icon
 
-A listbox item can have *non standard* end [icons](?path=/docs/icon-gallery--page) can be provided to handle special cases like displaying a list of icons.
+A listbox item can have *non standard* end [icons](?path=/docs/icon-gallery--docs) can be provided to handle special cases like displaying a list of icons.
 
 However, think twice before adding *end* icons, *start* icons should be your go to.
 
@@ -62,7 +62,7 @@ A listbox item can have a **single line** description.
 
 <Canvas of={ListboxStories.ItemDescription} />
 
-A description can be paired with an [icon](?path=/docs/icon-gallery--page).
+A description can be paired with an [icon](?path=/docs/icon-gallery--docs).
 
 <Canvas of={ListboxStories.ItemDescriptionIcon} />
 

--- a/packages/components/src/lozenge/docs/Lozenge.mdx
+++ b/packages/components/src/lozenge/docs/Lozenge.mdx
@@ -46,7 +46,7 @@ This is the lozenge that should be used in most situations.
 
 ### Icon
 
-An [icon](?path=/docs/icon-gallery--page) is used to make it easier for the user to understand the intent of the Lozenge. It is strongly recommended to use a Minor Icon in this particular use case.
+An [icon](?path=/docs/icon-gallery--docs) is used to make it easier for the user to understand the intent of the Lozenge. It is strongly recommended to use a Minor Icon in this particular use case.
 
 <Canvas of={LozengeStories.IconStory} />
 

--- a/packages/components/src/menu/docs/Menu.mdx
+++ b/packages/components/src/menu/docs/Menu.mdx
@@ -42,13 +42,13 @@ A menu items can be separated by dividers.
 
 ### Item icon
 
-A menu item can have [icons](?path=/docs/icon-gallery--page).
+A menu item can have [icons](?path=/docs/icon-gallery--docs).
 
 <Canvas of={MenuStories.ItemIcon} />
 
 ### Item end icon
 
-A select item can have *non standard* end [icons](?path=/docs/icon-gallery--page) can be provided to handle special cases like displaying a list of icons. However, think twice before adding *end* icons, *start* icons should be your go-to.
+A select item can have *non standard* end [icons](?path=/docs/icon-gallery--docs) can be provided to handle special cases like displaying a list of icons. However, think twice before adding *end* icons, *start* icons should be your go-to.
 
 <Canvas of={MenuStories.ItemEndIcon} />
 
@@ -58,7 +58,7 @@ A menu item can have a **single line** description.
 
 <Canvas of={MenuStories.ItemDescription} />
 
-A description can be paired with an [icon](?path=/docs/icon-gallery--page).
+A description can be paired with an [icon](?path=/docs/icon-gallery--docs).
 
 <Canvas of={MenuStories.ItemDescriptionIcon} />
 

--- a/packages/components/src/modal/docs/Modal.mdx
+++ b/packages/components/src/modal/docs/Modal.mdx
@@ -114,7 +114,7 @@ The `open` state can be handled in controlled mode.
 You don't have to use a `ModalTrigger` component if it doesn't fit your needs. A modal component can be used on it's own with any custom trigger which follow a few rules:
 
 - The custom trigger provide a valid `<DialogTriggerContext>` with a `close` function.
-- The custom trigger is responsible of show/hide the modal. This is usually done in combination with an [overlay](?path=/docs/overlay--page) component.
+- The custom trigger is responsible of show/hide the modal. This is usually done in combination with an [overlay](?path=/docs/overlay--docs) component.
 
 <Canvas of={ModalStories.CustomTrigger} />
 

--- a/packages/components/src/number-input/docs/NumberInput.mdx
+++ b/packages/components/src/number-input/docs/NumberInput.mdx
@@ -37,7 +37,7 @@ A number input value can be forced between min & max boundaries.
 
 ### Icon
 
-A number input can have an [icon](?path=/docs/icon-gallery--page).
+A number input can have an [icon](?path=/docs/icon-gallery--docs).
 
 <Canvas of={NumberInputStories.Icon} />
 

--- a/packages/components/src/radio/docs/Radio.mdx
+++ b/packages/components/src/radio/docs/Radio.mdx
@@ -42,7 +42,7 @@ Or the whole group.
 
 ### Icon
 
-A radio can have [icons](?path=/docs/icon-gallery--page) after its text.
+A radio can have [icons](?path=/docs/icon-gallery--docs) after its text.
 
 <Canvas of={RadioGroupStories.Icon} />
 

--- a/packages/components/src/select/docs/Select.mdx
+++ b/packages/components/src/select/docs/Select.mdx
@@ -39,13 +39,13 @@ A select items can be group by sections.
 
 ### Item icon
 
-A select item can have [icons](?path=/docs/icon-gallery--page).
+A select item can have [icons](?path=/docs/icon-gallery--docs).
 
 <Canvas of={SelectStories.ItemIcon} />
 
 ### Item end icon
 
-A select item can have *non standard* end [icons](?path=/docs/icon-gallery--page) for special cases like displaying a list of icons. However, think twice before adding *end* icons, as *start* icons should be your go-to.
+A select item can have *non standard* end [icons](?path=/docs/icon-gallery--docs) for special cases like displaying a list of icons. However, think twice before adding *end* icons, as *start* icons should be your go-to.
 
 <Canvas of={SelectStories.ItemEndIcon} />
 
@@ -55,7 +55,7 @@ A select item can have a description.
 
 <Canvas of={SelectStories.ItemDescription} />
 
-A description can be paired with an [icon](?path=/docs/icon-gallery--page).
+A description can be paired with an [icon](?path=/docs/icon-gallery--docs).
 
 <Canvas of={SelectStories.ItemDescriptionIcon} />
 

--- a/packages/components/src/styling/docs/ThemeProvider.mdx
+++ b/packages/components/src/styling/docs/ThemeProvider.mdx
@@ -16,7 +16,7 @@ import * as ThemeProviderStories from "./ThemeProvider.stories.tsx";
 
 ## Usage
 
-Orbiter components rely on the `ThemeProvider` to define the [color scheme](?path=/docs/color-schemes--page) they need to render accurately. We recommended you declare a theme provider at the root of your application but if you prefer, you can declare them as needed instead.
+Orbiter components rely on the `ThemeProvider` to define the [color scheme](?path=/docs/color-schemes--docs) they need to render accurately. We recommended you declare a theme provider at the root of your application but if you prefer, you can declare them as needed instead.
 
 <Canvas of={ThemeProviderStories.Example} />
 

--- a/packages/components/src/styling/src/theming/ThemeProvider.tsx
+++ b/packages/components/src/styling/src/theming/ThemeProvider.tsx
@@ -80,7 +80,7 @@ InnerThemeProvider.defaultElement = DefaultElement;
 /**
  * Container used to define the theme and color scheme to use.
  *
- * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/theme-provider--page)
+ * [Documentation](https://wl-orbiter-website.netlify.app/?path=/docs/theme-provider--docs)
 */
 export const ThemeProvider = forwardRef<any, OmitInternalProps<InnerThemeProviderProps>>((props, ref) => (
     <InnerThemeProvider {...props} forwardedRef={ref} />

--- a/packages/components/src/switch/docs/Switch.mdx
+++ b/packages/components/src/switch/docs/Switch.mdx
@@ -64,7 +64,7 @@ A switch can be disabled.
 
 ### Icon
 
-A switch can have [icons](?path=/docs/icon-gallery--page) after his text.
+A switch can have [icons](?path=/docs/icon-gallery--docs) after his text.
 
 <Canvas of={SwitchStories.IconStory} />
 

--- a/packages/components/src/tabs/docs/Tabs.mdx
+++ b/packages/components/src/tabs/docs/Tabs.mdx
@@ -1,4 +1,4 @@
-import { ArgTypes, Meta, Canvas } from "@storybook/addon-docs";
+import { ArgTypes, Meta, Canvas } from "@storybook/blocks";
 import { ComponentInfo, Tagline } from "@stories/components";
 import { InnerContent, InnerHeader } from "@components/placeholders";
 import { InnerItem } from "@components/collection";

--- a/packages/components/src/tabs/docs/Tabs.mdx
+++ b/packages/components/src/tabs/docs/Tabs.mdx
@@ -36,7 +36,7 @@ A default tab.
 
 ### Icon
 
-A tab can contain [icons](?path=/docs/icon-gallery--page).
+A tab can contain [icons](?path=/docs/icon-gallery--docs).
 
 <Canvas of={TabStories.Icon} />
 

--- a/packages/components/src/tag/docs/Tag.mdx
+++ b/packages/components/src/tag/docs/Tag.mdx
@@ -53,13 +53,13 @@ A tag can contain [avatars](?path=/docs/avatar--default-story). An avatar is use
 
 ### Icon
 
-A tag can contain [icons](?path=/docs/icon-gallery--page). An icon is used when it can make it easier for the user to understand the meaning.
+A tag can contain [icons](?path=/docs/icon-gallery--docs). An icon is used when it can make it easier for the user to understand the meaning.
 
 <Canvas of={TagStories.Icon} />
 
 ### End icon
 
-*Non standard* end [icons](?path=/docs/icon-gallery--page) can be provided *only if* you have to render a [list of icons](?path=/docs/icon--default-story#icon-list).
+*Non standard* end [icons](?path=/docs/icon-gallery--docs) can be provided *only if* you have to render a [list of icons](?path=/docs/icon--default-story#icon-list).
 
 <Canvas of={TagStories.EndIcon} />
 

--- a/packages/components/src/text-input/docs/TextInput.mdx
+++ b/packages/components/src/text-input/docs/TextInput.mdx
@@ -31,7 +31,7 @@ A text input can have a value.
 
 ### Icon
 
-A text input can contain an [icon](?path=/docs/icon-gallery--page).
+A text input can contain an [icon](?path=/docs/icon-gallery--docs).
 
 <Canvas of={TextInputStories.IconStory} />
 

--- a/packages/components/src/typography/docs/Text.mdx
+++ b/packages/components/src/typography/docs/Text.mdx
@@ -21,7 +21,7 @@ import * as TextStories from "./Text.stories.tsx";
 
 ### Size
 
-You can alter the size of the text by specifying a `size` prop. The available sizes match Orbiter typography type scale (a type scale is a set of [font-size](?path=/docs/tokens--page#font-sizes) and [line-height](?path=/docs/tokens--page#line-heights) pairs).
+You can alter the size of the text by specifying a `size` prop. The available sizes match Orbiter typography type scale (a type scale is a set of [font-size](?path=/docs/tokens--docs#font-sizes) and [line-height](?path=/docs/tokens--docs#line-heights) pairs).
 
 <Canvas of={TextStories.Size} />
 


### PR DESCRIPTION
Issue: https://workleap.atlassian.net/browse/DS-414

## Summary

While migrating to the newer version of storybook, storybook removed some classes that we were using and broke the styling on our documentation page, this PR fixes some of those styles.

Also, it changed urls from "--page" to "--docs", so I also changed and fixed that.
