### PR TITLE
Fix ArgTypes for Item in Accordion

### DIFF
--- a/packages/components/src/accordion/docs/Accordion.mdx
+++ b/packages/components/src/accordion/docs/Accordion.mdx
@@ -97,7 +97,7 @@ The `expandedKeys` state can be handled in controlled mode.
     compact
 />
 
-<ArgTypes of={Item} sort="alpha" />
+<ArgTypes of={InnerItem} sort="alpha" />
 
 ### Content
 


### PR DESCRIPTION
Issue: https://workleap.atlassian.net/browse/DS-475

## Summary

Item's args table was not working in Accordion. This PR fixes this.

## What I did

We were not sending the proper value to ArgsType mdx table.

## How to test

See the table In storybook
