### PR TITLE
fix urls not being the right and hierarchy of the icon page

### DIFF
--- a/docs/materials/icons.mdx
+++ b/docs/materials/icons.mdx
@@ -9,11 +9,11 @@ import { Preview } from "@stories/components";
 
 # Icons
 
-Orbiter doesn't provide any icons to consumers. Common icons are provided by [Hopper's icon package](https://hopper.workleap.design/icons/react-icons/library), `@hopper-ui/icons`. To start using Hopper Icons, follow the [Hopper documentation](https://hopper.workleap.design/icons/react-icons/installation).
+Orbiter doesn't provide any icons to consumers. Common icons are provided by [Hopper's icon package](https://npmjs.com/package/@hopper-ui/icons), `@hopper-ui/icons`. To start using Hopper Icons, follow the [Hopper documentation](https://hopper.workleap.design/icons/overview/introduction).
 
 ## Icon library
 
-The icon library is available in the [Hopper documentation](https://hopper.workleap.design/icons/react-icons/library).
+The icon library is available in the [Hopper documentation](https://hopper.workleap.design/icons/react-icons/icon-library).
 
 ## Creating your custom icons
 
@@ -68,7 +68,7 @@ function MyIcon(props: CreatedIconProps) {
 
 ## Usage
 
-## Sizing
+### Sizing
 
 Icons support t-shirt sizing. When used inside another Hopper component, they'll generally be sized automatically, but if you use icons standalone, you can use the size prop to control the sizing. The default size is "md".
 
@@ -78,7 +78,7 @@ Icons support t-shirt sizing. When used inside another Hopper component, they'll
 <MyIcon size="lg" />
 `} />
 
-## Styling
+### Styling
 
 The color of the icon can be change using the `fill` prop.
 All the styled system props are also available.


### PR DESCRIPTION
- Some links in the Icon documentation were pointing to 404 pages. This has been fixed.
- The hierarchy of the Icon documentation page was off. The hierarchy has been reworked.